### PR TITLE
Add Sky Feeder for Bluesky timelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Stream Spigot is a collection of tools for consuming real time-ish data sources at a manageable pace. The active application is the Cloudflare/SvelteKit worker in `worker/`. The old App Engine implementation and retired tools live in `legacy/` for reference only.
 
-Masto Feeder signs in with Mastodon, reads the user's timeline, and renders it as an Atom feed or debug HTML. Tweeter Feeder reads public Twitter/X timelines through private web endpoints and renders them through the same shared feed/status pipeline.
+Masto Feeder signs in with Mastodon, reads the user's timeline, and renders it as an Atom feed or debug HTML. Sky Feeder signs in with Bluesky through AT Protocol OAuth, reads the user's home timeline, and renders it as Atom, JSON Feed, or debug HTML. Tweeter Feeder reads public Twitter/X timelines through private web endpoints and renders them through the same shared feed/status pipeline.
 
 ## Active Architecture
 
@@ -15,6 +15,11 @@ Masto Feeder signs in with Mastodon, reads the user's timeline, and renders it a
 - Tweeter Feeder request handling is centralized in `worker/src/lib/tweeter-feeder/controller.ts`.
 - `worker/src/lib/tweeter-feeder/fetcher.ts` handles Twitter/X auth, private GraphQL fetches, response parsing, session cooldowns, and caching.
 - `worker/src/lib/tweeter-feeder/status-adapter.ts` converts parsed Twitter/X tweets into provider-neutral `Status` objects.
+- Sky Feeder request handling is centralized in `worker/src/lib/sky-feeder/controller.ts`.
+- `worker/src/lib/sky-feeder/oauth.ts` builds the AT Protocol OAuth client, exposes client metadata/JWKS data, and restores OAuth sessions.
+- `worker/src/lib/sky-feeder/feed.ts` fetches the Bluesky home timeline with `@atproto/api`.
+- `worker/src/lib/sky-feeder/status-adapter.ts` converts Bluesky feed posts, reposts, quotes, images, videos, and external cards into provider-neutral `Status` objects.
+- Small shared feeder helpers live in `worker/src/lib/feeder`.
 - `worker/src/lib/status/feed.ts` renders normalized statuses as Atom or debug HTML with `svelte/server`.
 - Shared feed-reader-friendly status UI lives in `worker/src/lib/components`, centered on `StatusDisplay.svelte` and related `StatusDisplay*` components.
 - Provider-neutral status types live in `worker/src/lib/status`.
@@ -48,13 +53,45 @@ or parsing breaks, compare the current web-client request with `fetcher.ts`,
 check that `ct0` is complete and matches in both cookie and header, and consult
 the Nitter repo for the closest known handling of current Twitter/X behavior.
 
+## Sky Feeder Bluesky Data Loading
+
+Sky Feeder uses AT Protocol OAuth rather than app passwords. It depends on
+`@atproto/api` and `@atproto/oauth-client-node`; keep `nodejs_compat` enabled
+in both Wrangler configs. The deployed Worker also needs the
+`ATPROTO_OAUTH_PRIVATE_JWK` secret. Generate it from `worker/` with
+`npm run gen:atproto-key`, then store the generated JSON object with
+`wrangler secret put ATPROTO_OAUTH_PRIVATE_JWK`.
+
+AT Protocol discoverable OAuth client IDs must be HTTPS URLs that are not
+loopback hosts and can be fetched by the Bluesky/ATProto OAuth server. Local
+HTTP is enough to smoke-test `/sky-feeder`,
+`/sky-feeder/oauth-client-metadata.json`, and `/sky-feeder/jwks.json`, but a
+complete Bluesky sign-in requires the deployed HTTPS Worker URL or a public
+HTTPS tunnel such as Tailscale Funnel pointed at the local Vite dev server.
+
+Sky Feeder data is stored in KV under `sky-feeder:` keys. OAuth state entries
+expire quickly; OAuth sessions are keyed by DID; Stream Spigot UI/feed sessions
+have their own random `sessionId` and `feedId`. Do not revoke the OAuth session
+on UI sign-out, because the randomly generated feed URL should continue to
+work.
+
+The high-level fetch flow is:
+
+1. Normalize the entered Bluesky handle and start AT Protocol OAuth.
+2. Store the OAuth callback session by DID, then create or update the Sky Feeder session and random feed ID.
+3. Restore the OAuth session for feed requests and call `agent.getTimeline`.
+4. Page through recent timeline results until the 12-hour window is exhausted, or one page in debug mode.
+5. Convert `app.bsky.feed.defs#feedViewPost` objects to the shared `Status` shape before rendering with the common Atom/JSON/debug HTML renderer.
+
 ## Status Display Pattern
 
 Provider API objects must stop at adapter boundaries. Shared Svelte display components should render normalized display objects and must not import Mastodon, Bluesky, Twitter/X, or other provider SDK types.
 
 For Masto Feeder, `worker/src/lib/masto-feeder/status-adapter.ts` is the Mastodon adapter. It converts `masto` statuses into generic `Status` objects and keeps Mastodon-specific behavior there, including local URL generation, content/title cleanup, quote handling, YouTube iframe extraction, SkyBridge image filtering, reply parent URLs, and debug JSON.
 
-Future Bluesky or Twitter/X tools should add provider-specific fetch/auth code and adapters that produce the same `Status` shape. They should reuse the shared display components rather than forking Mastodon-specific markup.
+For Sky Feeder, `worker/src/lib/sky-feeder/status-adapter.ts` is the Bluesky adapter. Keep AT Protocol record/view objects out of shared Svelte components. Map rich text facets to HTML, reposts to `StatusRepost`, quote embeds to nested `Status`, media embeds to attachments, and external embeds to cards at the adapter boundary.
+
+Future provider tools should add provider-specific fetch/auth code and adapters that produce the same `Status` shape. They should reuse the shared display components rather than forking provider-specific markup.
 
 Use plain serializable status data for the shared contract. Avoid presenter classes in the shared status layer unless there is a concrete need that cannot be handled by adapter-side normalization.
 
@@ -75,6 +112,7 @@ Run commands from `worker/` unless noted otherwise.
 
 - `npm install` installs dependencies.
 - `npm run dev` starts the canonical SvelteKit dev server on `localhost:3413`, with HMR and local Cloudflare bindings such as `STREAMSPIGOT` KV.
+- `npm run gen:atproto-key` generates a private JWK JSON object for the `ATPROTO_OAUTH_PRIVATE_JWK` secret used by Sky Feeder OAuth.
 - `npm run types:worker` regenerates `worker-configuration.d.ts` from Wrangler binding config.
 - `npm run check` verifies generated Worker types, then runs Svelte and TypeScript checks.
 - `npm run build` builds the app.
@@ -104,7 +142,11 @@ For Worker/dev tooling changes, verify all three local paths when feasible:
 `npm run dev` on port 3413, `npm run preview` on port 4413, and
 `npm run preview:worker` on port 5413. Smoke-test `/` and the KV-backed
 `/tweeter-feeder/statusz` endpoint; `statusz` should return `ok: true` when
-local Tweeter Feeder sessions are configured.
+local Tweeter Feeder sessions are configured. For Sky Feeder, also smoke-test
+`/sky-feeder`, `/sky-feeder/oauth-client-metadata.json`, and
+`/sky-feeder/jwks.json` with a local `ATPROTO_OAUTH_PRIVATE_JWK` value.
+End-to-end Bluesky OAuth requires non-loopback HTTPS, for example through
+Tailscale Funnel.
 
 ## Code Style Notes
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Stream Spigot is a collection of tools to make consumption of real time-ish datasources more manageable. The active tools are:
 - **Masto Feeder**: lets you read your Mastodon timeline in a feed reader.
 - **Tweeter Feeder**: lets you generate feeds for public X/Twitter accounts.
+- **Sky Feeder**: lets you read your Bluesky timeline in a feed reader.
 
 A running instance is at [www.streamspigot.com](http://www.streamspigot.com/).
 
@@ -45,6 +46,33 @@ running Svelte and TypeScript checks. The type generation uses
 `wrangler.types.toml`, which mirrors the deployed bindings without importing
 the generated Worker build output into `svelte-check`.
 
+## Sky Feeder
+
+Sky Feeder signs in with Bluesky through AT Protocol OAuth, stores OAuth and
+feed sessions in the existing `STREAMSPIGOT` KV namespace, and renders the home
+timeline through the shared Atom/JSON Feed status renderer. It uses
+`@atproto/api` and `@atproto/oauth-client-node`, so the Worker config enables
+`nodejs_compat`.
+
+Before using Sky Feeder in a deployed environment, generate an OAuth signing key
+and store it as a Wrangler secret:
+
+```bash
+cd worker
+npm run gen:atproto-key
+wrangler secret put ATPROTO_OAUTH_PRIVATE_JWK
+```
+
+Paste the generated JSON object as the secret value. The public key is exposed
+automatically from `/sky-feeder/jwks.json`, and OAuth client metadata is exposed
+from `/sky-feeder/oauth-client-metadata.json`.
+
+AT Protocol discoverable OAuth client IDs must be HTTPS URLs that are not
+loopback hosts and can be fetched by the Bluesky/ATProto OAuth server. Local
+HTTP is enough to smoke-test `/sky-feeder`, the metadata route, and the JWKS
+route, but real Bluesky sign-in requires the deployed HTTPS Worker URL or a
+public HTTPS tunnel such as Tailscale Funnel pointed at the local Vite dev
+server.
 
 # Masto Feeder
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Stream Spigot is a collection of tools to make consumption of real time-ish data
 - **Tweeter Feeder**: lets you generate feeds for public X/Twitter accounts.
 - **Sky Feeder**: lets you read your Bluesky timeline in a feed reader.
 
-A running instance is at [www.streamspigot.com](http://www.streamspigot.com/).
+You can run it yourself, but there is also a canonical hosted at [streamspigot.com](https://streamspigot.com/).
 
 The implementation is a Cloudflare Worker in the [`worker/`](worker/) directory. Earlier tools (Tweet Digest, Feed Playback, Bird Feeder) and the original App Engine implementation are preserved in [`legacy/`](legacy/).
 
@@ -149,4 +149,4 @@ To deploy the app, assuming you've run `wrangler login` to set up Cloudflare cre
 npm run deploy
 ```
 
-It will be running at [streamspigot.mihai-parparita.workers.dev](https://streamspigot.mihai-parparita.workers.dev) (alternate/development route for the main `www.streamspigot.com` domain route).
+It will be running at [streamspigot.mihai-parparita.workers.dev](https://streamspigot.mihai-parparita.workers.dev) (alternate/development route for the main `streamspigot.com` domain route).

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -8,6 +8,12 @@
             "name": "worker",
             "version": "0.0.1",
             "dependencies": {
+                "@atproto-labs/did-resolver": "^0.3.0",
+                "@atproto-labs/handle-resolver": "^0.4.0",
+                "@atproto/api": "^0.20.5",
+                "@atproto/did": "^0.4.0",
+                "@atproto/oauth-client-node": "^0.4.0",
+                "@atproto/syntax": "^0.6.1",
                 "htmlparser2": "^10.0.0",
                 "lite-youtube-embed": "^0.3.4",
                 "masto": "^7.5.0"
@@ -34,7 +40,346 @@
                 "wrangler": "^4.90.0"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
+                "node": "^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@atproto-labs/did-resolver": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.3.0.tgz",
+            "integrity": "sha512-6w8UxJQVj40TqKJm+D5s6pcH45eWH/KvfAR+gYC6KOux/mM7ZI3IKOhI1Gq7GIte1eOp9WXwASN1RQAFYZ4MFw==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/fetch": "^0.3.0",
+                "@atproto-labs/pipe": "^0.2.0",
+                "@atproto-labs/simple-store": "^0.4.0",
+                "@atproto-labs/simple-store-memory": "^0.2.0",
+                "@atproto/did": "^0.4.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/fetch": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.3.0.tgz",
+            "integrity": "sha512-yZhNsRZyqhjmzHlXmE9k6XU0f6+ynfNyrHhB4FlEyUjkBvf5vNLjdJyBq+Jp7ISGMigA1fn2lAgaE/qkrVo9iw==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/pipe": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/fetch-node": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/fetch-node/-/fetch-node-0.3.0.tgz",
+            "integrity": "sha512-Dj4OlW8E7Hyk0vpJ31ThUp5PCXMVi2iwPhavWkiGhjLx+pAhcEsIEnvV2cf+cGJcYKXczLwIl1agoLUMSZq1ag==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/fetch": "^0.3.0",
+                "@atproto-labs/pipe": "^0.2.0",
+                "ipaddr.js": "^2.1.0",
+                "undici": "^6.14.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/fetch-node/node_modules/undici": {
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+            "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/@atproto-labs/handle-resolver": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver/-/handle-resolver-0.4.0.tgz",
+            "integrity": "sha512-+q4j19YKNenWHoOJQrs2nv9vDornYxQXLSUpFR3q3l0gFTUq/OHk0Hvw98I9044CbxQ6pSnlxxU7OfWFyaaw2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/simple-store": "^0.4.0",
+                "@atproto-labs/simple-store-memory": "^0.2.0",
+                "@atproto/did": "^0.4.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/handle-resolver-node": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver-node/-/handle-resolver-node-0.2.0.tgz",
+            "integrity": "sha512-3hP3exJiNr7tdI2M3fCnUvPX3oA1663XsIUwZTTzxQf+R5TDvtcoJiWwp5KdCI1u2mVPpWrxKzjEEnrVQ4va6A==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/fetch-node": "^0.3.0",
+                "@atproto-labs/handle-resolver": "^0.4.0",
+                "@atproto/did": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/identity-resolver": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/identity-resolver/-/identity-resolver-0.4.0.tgz",
+            "integrity": "sha512-6ZGeWminDTXfYE/jw6BqXm5Nrv2lTBox8wHsnWUQkOs2m0oam47dMcMf3KQfo3hNhRZmTY2JB/F0woRV5MvhpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/did-resolver": "^0.3.0",
+                "@atproto-labs/handle-resolver": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/pipe": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.2.0.tgz",
+            "integrity": "sha512-89X6gv+8/SiZYwJ4+Hw8iaU1WymbElZO6LsMgHd+c1XFs/78KhsIL4xp0RCs7/W8izK9BxaTEnYN5csRmwQ99Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/simple-store": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.4.0.tgz",
+            "integrity": "sha512-sbPEju2QXzN6lGWfr5p2Kg82ZeaG1UyVFOrMQc4eCjUvxGOjIxuYOVIiTuPTFOC5Rsvsb8jMOmLjLi8FR/CMYw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto-labs/simple-store-memory": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.2.0.tgz",
+            "integrity": "sha512-nDZIS6vOBvR8NqObGmj0GFSdz3N6gyQ7ny3l/uiezwuCWShsxtA9OkYcjaQ7Kw3hydXTe4iEGu/BDOACncnxDg==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/simple-store": "^0.4.0",
+                "lru-cache": "^10.2.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/api": {
+            "version": "0.20.5",
+            "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.20.5.tgz",
+            "integrity": "sha512-VqkRYKR9vRRk36NhtytJz5TPhNtR1hczCcfM+bWoOK6MBvWUT8HwelufrycFAIbFIH7n4ws+5UbnLYpTIBQZ6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/common-web": "^0.5.0",
+                "@atproto/lexicon": "^0.7.1",
+                "@atproto/syntax": "^0.6.1",
+                "@atproto/xrpc": "^0.8.0",
+                "await-lock": "^3.0.0",
+                "multiformats": "^13.0.0",
+                "tlds": "^1.234.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/common-web": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.5.0.tgz",
+            "integrity": "sha512-ReWnkuZdDU/74/I47gaI26uxQjHmpq4edp41NnZZQ5vIIKGb7Ei6pZHzDTUD9JURo109SKrPx9RMP2IQm0fOKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/lex-data": "^0.1.0",
+                "@atproto/lex-json": "^0.1.0",
+                "@atproto/syntax": "^0.6.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/did": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.4.0.tgz",
+            "integrity": "sha512-OADX1NXCkScMkNJmSQnTUfPoDJ2IoOUTtqVfuY4z+a8//JDIsY6FDygv3GR8Sh2laz5qodlCA7XM+u6XVine3g==",
+            "license": "MIT",
+            "dependencies": {
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/jwk": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@atproto/jwk/-/jwk-0.7.0.tgz",
+            "integrity": "sha512-HJ0crIKTbeTIiXCodgcgpaTcfKmeUE4IawjpoiVav1KFiIrD8ML2c7NdLETo8XnHuuj6DNzCtfD/381od/QjkA==",
+            "license": "MIT",
+            "dependencies": {
+                "multiformats": "^13.0.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/jwk-jose": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@atproto/jwk-jose/-/jwk-jose-0.2.0.tgz",
+            "integrity": "sha512-emI0XXWoZvcy64Q1NnVictPtez3p2jWUU5TMHxalIqo917z9QEJ/aMcso6X9YPfnbL8sa1n6VGo+5THBMobZzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/jwk": "^0.7.0",
+                "jose": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/jwk-webcrypto": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@atproto/jwk-webcrypto/-/jwk-webcrypto-0.3.0.tgz",
+            "integrity": "sha512-llguCJA5vlaTfNhWF1RTiRfg0HWCehTumZpQB84ZkhdJp6TBWgfMw431K6B2bE4FbGB3824v/+Q3Y2y8OQEltQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/jwk": "^0.7.0",
+                "@atproto/jwk-jose": "^0.2.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/lex-data": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.1.1.tgz",
+            "integrity": "sha512-/xza8nU/YhtzhETnHL3QKKofaJ28/0NCzhT7LaYoUkm8EgypWp5ykEtmW52yLhQM2JF6fVa25g1soQmNTGqtSg==",
+            "license": "MIT",
+            "dependencies": {
+                "multiformats": "^13.0.0",
+                "tslib": "^2.8.1",
+                "uint8arrays": "^5.0.0",
+                "unicode-segmenter": "^0.14.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/lex-json": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.1.0.tgz",
+            "integrity": "sha512-oWUrRMwFyWpmi/5k1Se3xBTbP06XdxBS5iFuUz9LmqItaPXwrWRD87a9ldPvINQ/A2/mn7J6/qug8sDVlhD+vQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/lex-data": "^0.1.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/lexicon": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.7.1.tgz",
+            "integrity": "sha512-voNfNED5KUxn3vpo7N5DMRblBDfWf7kSfdKhJFC1RrLCxg38YbBzzURNVQJ32bp13Oot8kYfyXBWxTgtKLvw8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/common-web": "^0.5.0",
+                "@atproto/syntax": "^0.6.1",
+                "multiformats": "^13.0.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/oauth-client": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@atproto/oauth-client/-/oauth-client-0.7.1.tgz",
+            "integrity": "sha512-lobofOc4hbxzT8NRmRbaW6CG7+MUd1BfRrJ8UEvYMiYCon34csKRfMcGgDZ/fnIjrWuMfwhjJGsIGq140YunJg==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/did-resolver": "^0.3.0",
+                "@atproto-labs/fetch": "^0.3.0",
+                "@atproto-labs/handle-resolver": "^0.4.0",
+                "@atproto-labs/identity-resolver": "^0.4.0",
+                "@atproto-labs/simple-store": "^0.4.0",
+                "@atproto-labs/simple-store-memory": "^0.2.0",
+                "@atproto/did": "^0.4.0",
+                "@atproto/jwk": "^0.7.0",
+                "@atproto/oauth-types": "^0.7.0",
+                "@atproto/xrpc": "^0.8.0",
+                "core-js": "^3",
+                "multiformats": "^13.0.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/oauth-client-node": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@atproto/oauth-client-node/-/oauth-client-node-0.4.0.tgz",
+            "integrity": "sha512-YmhF0xWSiq2JI86Y/Kryi0PeTnVvIVjJ8lrK+LX3MPLQiYF+EYYUQGHrRccJLzWSVCxKNc+0lbNY8Z8JDittWg==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto-labs/did-resolver": "^0.3.0",
+                "@atproto-labs/handle-resolver-node": "^0.2.0",
+                "@atproto-labs/simple-store": "^0.4.0",
+                "@atproto/did": "^0.4.0",
+                "@atproto/jwk": "^0.7.0",
+                "@atproto/jwk-jose": "^0.2.0",
+                "@atproto/jwk-webcrypto": "^0.3.0",
+                "@atproto/oauth-client": "^0.7.0",
+                "@atproto/oauth-types": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/oauth-types": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@atproto/oauth-types/-/oauth-types-0.7.0.tgz",
+            "integrity": "sha512-4o1pRBTnZrIqaXH3jg9K2XwkTlRb7ohp2BArQ1gNPYp2znrRiELmwjxqR3CH5KD1Dz64kJXoEkbeLKl0devkNw==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/did": "^0.4.0",
+                "@atproto/jwk": "^0.7.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/syntax": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.6.1.tgz",
+            "integrity": "sha512-kA4dQDoMPpWCH8N0Q4KoSq024u5MkVfDVa8DdhyLjGA72z/khbOf1jXKPv7NIL2oEc9aj7geKELdvqyf4ogopA==",
+            "license": "MIT",
+            "dependencies": {
+                "iso-datestring-validator": "^2.2.2",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@atproto/xrpc": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.8.0.tgz",
+            "integrity": "sha512-NJy02bIKrWlE2NQkRV1kT0Cj0ixbuxlF/MejBdo4cPWAa9v3oZexvAcjjb0zaOYeABkaU14iyIhvn2G4e/oLpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@atproto/lexicon": "^0.7.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@cloudflare/kv-asset-handler": {
@@ -2151,6 +2496,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/await-lock": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-3.0.0.tgz",
+            "integrity": "sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==",
+            "license": "MIT"
+        },
         "node_modules/axobject-query": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2231,6 +2582,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+            "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/cross-spawn": {
@@ -2875,6 +3237,15 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/ipaddr.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2915,6 +3286,12 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/iso-datestring-validator": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+            "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+            "license": "MIT"
+        },
         "node_modules/isomorphic-ws": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
@@ -2922,6 +3299,15 @@
             "license": "MIT",
             "peerDependencies": {
                 "ws": "*"
+            }
+        },
+        "node_modules/jose": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+            "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
             }
         },
         "node_modules/json-buffer": {
@@ -3286,6 +3672,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3394,6 +3786,12 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/multiformats": {
+            "version": "13.4.2",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+            "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+            "license": "Apache-2.0 OR MIT"
         },
         "node_modules/nanoid": {
             "version": "3.3.12",
@@ -4069,6 +4467,15 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
+        "node_modules/tlds": {
+            "version": "1.261.0",
+            "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+            "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+            "license": "MIT",
+            "bin": {
+                "tlds": "bin.js"
+            }
+        },
         "node_modules/totalist": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -4105,7 +4512,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/type-check": {
@@ -4160,6 +4566,15 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/uint8arrays": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+            "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "multiformats": "^13.0.0"
+            }
+        },
         "node_modules/undici": {
             "version": "7.24.8",
             "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
@@ -4187,6 +4602,12 @@
             "dependencies": {
                 "pathe": "^2.0.3"
             }
+        },
+        "node_modules/unicode-segmenter": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+            "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -4403,9 +4824,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4482,6 +4903,15 @@
             "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
         }
     }
 }

--- a/worker/package.json
+++ b/worker/package.json
@@ -8,6 +8,7 @@
         "preview": "npm run build && vite preview",
         "preview:worker": "npm run build && wrangler dev --port 5413",
         "deploy": "npm run build && wrangler deploy",
+        "gen:atproto-key": "node scripts/gen-atproto-key.mjs",
         "types:worker": "wrangler types worker-configuration.d.ts --config wrangler.types.toml --env-file worker-types.env --include-runtime false",
         "types:worker:check": "wrangler types worker-configuration.d.ts --config wrangler.types.toml --env-file worker-types.env --include-runtime false --check",
         "check": "npm run types:worker:check && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -37,7 +38,7 @@
         "wrangler": "^4.90.0"
     },
     "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.13.0 || >=24"
     },
     "type": "module",
     "prettier": {
@@ -51,6 +52,12 @@
         "arrowParens": "avoid"
     },
     "dependencies": {
+        "@atproto-labs/did-resolver": "^0.3.0",
+        "@atproto-labs/handle-resolver": "^0.4.0",
+        "@atproto/api": "^0.20.5",
+        "@atproto/did": "^0.4.0",
+        "@atproto/oauth-client-node": "^0.4.0",
+        "@atproto/syntax": "^0.6.1",
         "htmlparser2": "^10.0.0",
         "lite-youtube-embed": "^0.3.4",
         "masto": "^7.5.0"

--- a/worker/scripts/gen-atproto-key.mjs
+++ b/worker/scripts/gen-atproto-key.mjs
@@ -1,0 +1,4 @@
+import {JoseKey} from "@atproto/oauth-client-node";
+
+const key = await JoseKey.generate(["ES256"], crypto.randomUUID());
+console.log(JSON.stringify(key.privateJwk));

--- a/worker/src/hooks.server.ts
+++ b/worker/src/hooks.server.ts
@@ -1,0 +1,32 @@
+import type {Handle} from "@sveltejs/kit";
+
+export const handle: Handle = ({event, resolve}) => {
+    const canonicalUrl = skyFeederCanonicalSignInUrl(
+        event.url,
+        event.request.method
+    );
+    if (canonicalUrl) {
+        return Response.redirect(canonicalUrl, 302);
+    }
+
+    return resolve(event);
+};
+
+function skyFeederCanonicalSignInUrl(
+    url: URL,
+    requestMethod: string
+): URL | null {
+    if (
+        requestMethod === "GET" &&
+        url.hostname.startsWith("www.") &&
+        (url.pathname === "/sky-feeder" || url.pathname === "/sky-feeder/")
+    ) {
+        const canonicalUrl = new URL(url);
+        // TODO(#9): replace this minimal Sky Feeder sign-in redirect with
+        // deliberate canonical host handling for all feeder auth and feed URLs.
+        canonicalUrl.hostname = url.hostname.replace(/^www\./, "");
+        return canonicalUrl;
+    }
+
+    return null;
+}

--- a/worker/src/hooks.server.ts
+++ b/worker/src/hooks.server.ts
@@ -1,10 +1,7 @@
 import type {Handle} from "@sveltejs/kit";
 
 export const handle: Handle = ({event, resolve}) => {
-    const canonicalUrl = skyFeederCanonicalSignInUrl(
-        event.url,
-        event.request.method
-    );
+    const canonicalUrl = skyFeederCanonicalUrl(event.url, event.request.method);
     if (canonicalUrl) {
         return Response.redirect(canonicalUrl, 302);
     }
@@ -12,17 +9,15 @@ export const handle: Handle = ({event, resolve}) => {
     return resolve(event);
 };
 
-function skyFeederCanonicalSignInUrl(
-    url: URL,
-    requestMethod: string
-): URL | null {
+function skyFeederCanonicalUrl(url: URL, requestMethod: string): URL | null {
     if (
         requestMethod === "GET" &&
         url.hostname.startsWith("www.") &&
-        (url.pathname === "/sky-feeder" || url.pathname === "/sky-feeder/")
+        (url.pathname === "/sky-feeder" ||
+            url.pathname.startsWith("/sky-feeder/"))
     ) {
         const canonicalUrl = new URL(url);
-        // TODO(#9): replace this minimal Sky Feeder sign-in redirect with
+        // TODO(#9): replace this minimal Sky Feeder host redirect with
         // deliberate canonical host handling for all feeder auth and feed URLs.
         canonicalUrl.hostname = url.hostname.replace(/^www\./, "");
         return canonicalUrl;

--- a/worker/src/lib/feeder/feed-options.ts
+++ b/worker/src/lib/feeder/feed-options.ts
@@ -1,0 +1,17 @@
+import type {FeedOptions, FeedOutputType} from "$lib/status/feed";
+
+export function parseFeedOptions(searchParams: URLSearchParams): FeedOptions {
+    return {
+        debug: searchParams.get("debug") === "true",
+        output: parseOutput(searchParams),
+        includeStatusJson: searchParams.get("includeStatusJson") === "true",
+    };
+}
+
+function parseOutput(searchParams: URLSearchParams): FeedOutputType {
+    const output = searchParams.get("output");
+    if (output === "html" || output === "atom" || output === "json") {
+        return output;
+    }
+    return searchParams.get("html") === "true" ? "html" : "atom";
+}

--- a/worker/src/lib/feeder/log.ts
+++ b/worker/src/lib/feeder/log.ts
@@ -1,0 +1,45 @@
+const SENSITIVE_LOG_FIELDS = [
+    "access_token",
+    "auth_token",
+    "client_assertion",
+    "client_secret",
+    "code",
+    "ct0",
+    "id_token",
+    "refresh_token",
+    "request_uri",
+    "state",
+    "token",
+];
+
+const SENSITIVE_LOG_FIELD_PATTERN = SENSITIVE_LOG_FIELDS.join("|");
+
+export function errorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return sanitizeLogString(error.message) ?? "";
+    }
+    if (typeof error === "string") {
+        return sanitizeLogString(error) ?? "";
+    }
+    try {
+        return sanitizeLogString(JSON.stringify(error)) ?? "";
+    } catch {
+        return sanitizeLogString(String(error)) ?? "";
+    }
+}
+
+export function sanitizeLogString(
+    value: string | null | undefined
+): string | undefined {
+    const queryParamPattern = new RegExp(
+        `([?&](?:${SENSITIVE_LOG_FIELD_PATTERN})=)[^&\\s]+`,
+        "gi"
+    );
+    const keyValuePattern = new RegExp(
+        `\\b(${SENSITIVE_LOG_FIELD_PATTERN})=\\S+`,
+        "gi"
+    );
+    return value
+        ?.replace(queryParamPattern, "$1[redacted]")
+        .replace(keyValuePattern, "$1=[redacted]");
+}

--- a/worker/src/lib/feeder/log.ts
+++ b/worker/src/lib/feeder/log.ts
@@ -28,6 +28,25 @@ export function errorMessage(error: unknown): string {
     }
 }
 
+export function errorSummary(error: unknown): ErrorSummary {
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: errorMessage(error),
+            code: errorField(error, "code"),
+            status: errorField(error, "status"),
+            stackFirstLine: sanitizeLogString(error.stack?.split("\n")[0]),
+            cause:
+                "cause" in error && error.cause
+                    ? errorSummary(error.cause)
+                    : undefined,
+        };
+    }
+    return {
+        message: errorMessage(error),
+    };
+}
+
 export function sanitizeLogString(
     value: string | null | undefined
 ): string | undefined {
@@ -42,4 +61,21 @@ export function sanitizeLogString(
     return value
         ?.replace(queryParamPattern, "$1[redacted]")
         .replace(keyValuePattern, "$1=[redacted]");
+}
+
+type ErrorSummary = {
+    name?: string;
+    message: string;
+    code?: string;
+    status?: string;
+    stackFirstLine?: string;
+    cause?: ErrorSummary;
+};
+
+function errorField(error: Error, field: string): string | undefined {
+    const value = (error as unknown as Record<string, unknown>)[field];
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+    return sanitizeLogString(String(value));
 }

--- a/worker/src/lib/feeder/prefs.ts
+++ b/worker/src/lib/feeder/prefs.ts
@@ -1,0 +1,13 @@
+export const DEFAULT_TIME_ZONE = "America/Los_Angeles";
+
+export type FeederPrefs = {
+    timeZone?: string;
+};
+
+export function resolveFeederPrefs(
+    prefs: FeederPrefs | undefined
+): Required<FeederPrefs> {
+    return {
+        timeZone: prefs?.timeZone ?? DEFAULT_TIME_ZONE,
+    };
+}

--- a/worker/src/lib/feeder/response.ts
+++ b/worker/src/lib/feeder/response.ts
@@ -1,0 +1,20 @@
+import type {FeedOutput} from "$lib/status/feed";
+
+export function feedOutputResponse({body, contentType}: FeedOutput): Response {
+    return new Response(new TextEncoder().encode(body), {
+        headers: {
+            "Content-Type": `${contentType}; charset=utf-8`,
+        },
+    });
+}
+
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+    const headers = new Headers(init.headers);
+    if (!headers.has("Content-Type")) {
+        headers.set("Content-Type", "application/json; charset=utf-8");
+    }
+    return new Response(`${JSON.stringify(body, null, 2)}\n`, {
+        ...init,
+        headers,
+    });
+}

--- a/worker/src/lib/html.ts
+++ b/worker/src/lib/html.ts
@@ -1,0 +1,7 @@
+export function escapeHtml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeHtmlAttribute(s: string): string {
+    return escapeHtml(s).replace(/"/g, "&quot;");
+}

--- a/worker/src/lib/masto-feeder/controller.ts
+++ b/worker/src/lib/masto-feeder/controller.ts
@@ -7,6 +7,7 @@ import {
     type RequestEvent,
 } from "@sveltejs/kit";
 import {createOAuthAPIClient, createRestAPIClient} from "$lib/masto";
+import {errorMessage, sanitizeLogString} from "$lib/feeder/log";
 import {MastoFeederKV} from "./kv";
 import {WorkerKV} from "../kv";
 import {
@@ -17,6 +18,8 @@ import {
 } from "./types";
 import type {FeedOptions, FeedOutputType} from "$lib/status/feed";
 import {renderTimelineFeed} from "./feed";
+import {feedOutputResponse} from "$lib/feeder/response";
+import {DEFAULT_TIME_ZONE} from "$lib/feeder/prefs";
 
 const SCOPES = ["read:accounts", "read:follows", "read:lists", "read:statuses"];
 
@@ -53,8 +56,18 @@ export class MastoFeederController {
     }
 
     async handleSignIn(instanceUrl: string): Promise<Redirect> {
-        const app = await this.#getOrCreateApp(instanceUrl);
-        const authRequest = await this.#createAuthRequest(instanceUrl);
+        let app: MastoFeederApp;
+        let authRequest: MastoFeederAuthRequest;
+        try {
+            app = await this.#getOrCreateApp(instanceUrl);
+            authRequest = await this.#createAuthRequest(instanceUrl);
+        } catch (error) {
+            console.error("Masto Feeder sign-in failed", {
+                instanceUrl: sanitizeLogString(instanceUrl),
+                message: errorMessage(error),
+            });
+            throw error;
+        }
 
         this.#cookies.set(
             AUTH_REQUEST_COOKIE_NAME,
@@ -98,44 +111,58 @@ export class MastoFeederController {
             return error(400, `Unknown app ${instanceUrl}`);
         }
 
-        const oauthMasto = createOAuthAPIClient({url: instanceUrl});
+        try {
+            const oauthMasto = createOAuthAPIClient({url: instanceUrl});
 
-        const {accessToken} = await oauthMasto.token.create({
-            grantType: "authorization_code",
-            clientId: app.clientId,
-            clientSecret: app.clientSecret,
-            redirectUri: this.#redirectUrl(),
-            scope: SCOPES.join(" "),
-            code,
-        });
+            const {accessToken} = await oauthMasto.token.create({
+                grantType: "authorization_code",
+                clientId: app.clientId,
+                clientSecret: app.clientSecret,
+                redirectUri: this.#redirectUrl(),
+                scope: SCOPES.join(" "),
+                code,
+            });
 
-        const apiMasto = createRestAPIClient({url: instanceUrl, accessToken});
-
-        const credentials = await apiMasto.v1.accounts.verifyCredentials();
-        const mastodonId = credentials.id;
-
-        let session = await this.#kv.getSessionByMastodonId(
-            instanceUrl,
-            mastodonId
-        );
-        if (session) {
-            session = await this.#kv.updateSessionToken(session, accessToken);
-        } else {
-            session = {
-                sessionId: crypto.randomUUID(),
-                feedId: crypto.randomUUID(),
-                mastodonId,
-                instanceUrl,
+            const apiMasto = createRestAPIClient({
+                url: instanceUrl,
                 accessToken,
-            };
-            await this.#kv.putSession(session);
-        }
+            });
 
-        this.#cookies.set(
-            SESSION_COOKIE_NAME,
-            session.sessionId,
-            SESSION_COOKIE_OPTIONS
-        );
+            const credentials = await apiMasto.v1.accounts.verifyCredentials();
+            const mastodonId = credentials.id;
+
+            let session = await this.#kv.getSessionByMastodonId(
+                instanceUrl,
+                mastodonId
+            );
+            if (session) {
+                session = await this.#kv.updateSessionToken(
+                    session,
+                    accessToken
+                );
+            } else {
+                session = {
+                    sessionId: crypto.randomUUID(),
+                    feedId: crypto.randomUUID(),
+                    mastodonId,
+                    instanceUrl,
+                    accessToken,
+                };
+                await this.#kv.putSession(session);
+            }
+
+            this.#cookies.set(
+                SESSION_COOKIE_NAME,
+                session.sessionId,
+                SESSION_COOKIE_OPTIONS
+            );
+        } catch (error) {
+            console.error("Masto Feeder sign-in callback failed", {
+                instanceUrl: sanitizeLogString(instanceUrl),
+                message: errorMessage(error),
+            });
+            throw error;
+        }
 
         return redirect(302, "/masto-feeder");
     }
@@ -207,31 +234,27 @@ export class MastoFeederController {
             return error(404, "Unknown feed ID");
         }
         const prefs = resolvePrefs(session.prefs);
-        const {body, contentType} = await renderTimelineFeed(
-            session,
-            this.timelineFeedUrl(session, options.output),
-            this.#baseUrl(),
-            {
-                instanceUrl: session.instanceUrl,
-                timeZone: prefs.timeZone,
-                useLocalUrls: prefs.useLocalUrls,
-                statusParentUrlGenerator: this.statusParentUrl.bind(
-                    this,
-                    session
-                ),
-                youtubeEmbedUrlGenerator: this.youtubeEmbedUrl.bind(
-                    this,
-                    session
-                ),
-            },
-            options
+        return feedOutputResponse(
+            await renderTimelineFeed(
+                session,
+                this.timelineFeedUrl(session, options.output),
+                this.#baseUrl(),
+                {
+                    instanceUrl: session.instanceUrl,
+                    timeZone: prefs.timeZone,
+                    useLocalUrls: prefs.useLocalUrls,
+                    statusParentUrlGenerator: this.statusParentUrl.bind(
+                        this,
+                        session
+                    ),
+                    youtubeEmbedUrlGenerator: this.youtubeEmbedUrl.bind(
+                        this,
+                        session
+                    ),
+                },
+                options
+            )
         );
-        const encodedBody = new TextEncoder().encode(body);
-        return new Response(encodedBody, {
-            headers: {
-                "Content-Type": `${contentType}; charset=utf-8`,
-            },
-        });
     }
 
     async #getOrCreateApp(instanceUrl: string): Promise<MastoFeederApp> {
@@ -323,7 +346,7 @@ export function resolvePrefs(
     prefs: MastoFeederPrefs | undefined
 ): Required<MastoFeederPrefs> {
     return {
-        timeZone: prefs?.timeZone ?? "America/Los_Angeles",
+        timeZone: prefs?.timeZone ?? DEFAULT_TIME_ZONE,
         useLocalUrls: prefs?.useLocalUrls ?? false,
     };
 }

--- a/worker/src/lib/sky-feeder/controller.ts
+++ b/worker/src/lib/sky-feeder/controller.ts
@@ -1,0 +1,239 @@
+import {
+    redirect,
+    type Cookies,
+    type Redirect,
+    type RequestEvent,
+} from "@sveltejs/kit";
+import {errorMessage, sanitizeLogString} from "$lib/feeder/log";
+import {feedOutputResponse, jsonResponse} from "$lib/feeder/response";
+import {resolveFeederPrefs} from "$lib/feeder/prefs";
+import {WorkerKV} from "$lib/kv";
+import {SkyFeederKV} from "./kv";
+import {
+    createSkyAgent,
+    createSkyOAuthClient,
+    OAUTH_SCOPE,
+    parsePrivateJwk,
+    skyClientMetadata,
+    skyJwks,
+} from "./oauth";
+import {renderTimelineFeed} from "./feed";
+import type {FeedOutputType, FeedOptions} from "$lib/status/feed";
+import type {SkyFeederPrefs, SkyFeederSession} from "./types";
+
+const SESSION_COOKIE_NAME = "skyfeeder-session";
+const SESSION_COOKIE_OPTIONS = {
+    path: "/sky-feeder",
+};
+
+export class SkyFeederController {
+    #kv: SkyFeederKV;
+    #appProtocol: string;
+    #appHost: string;
+    #cookies: Cookies;
+    #privateJwk: string | undefined;
+
+    constructor(event: RequestEvent) {
+        const {cookies, platform, url} = event;
+        this.#kv = new SkyFeederKV(WorkerKV.fromEvent(event));
+        this.#appProtocol = url.protocol;
+        this.#appHost = url.host;
+        this.#cookies = cookies;
+        this.#privateJwk = (
+            platform?.env as {ATPROTO_OAUTH_PRIVATE_JWK?: string} | undefined
+        )?.ATPROTO_OAUTH_PRIVATE_JWK;
+    }
+
+    async getSession(): Promise<SkyFeederSession | null> {
+        const sessionId = this.#cookies.get(SESSION_COOKIE_NAME);
+        if (!sessionId) {
+            return null;
+        }
+        return this.#kv.getSessionById(sessionId);
+    }
+
+    async getProfile(session: SkyFeederSession) {
+        const agent = await this.#getAgent(session.did);
+        const profile = await agent.getProfile({actor: session.did});
+        return profile.data;
+    }
+
+    async handleSignIn(handle: string): Promise<Redirect> {
+        let authUrl: URL;
+        try {
+            const oauthClient = await this.#getOAuthClient();
+            authUrl = await oauthClient.authorize(handle, {
+                scope: OAUTH_SCOPE,
+                state: crypto.randomUUID(),
+            });
+        } catch (error) {
+            console.error("Sky Feeder sign-in failed", {
+                handle,
+                message: errorMessage(error),
+            });
+            throw error;
+        }
+
+        return redirect(302, authUrl);
+    }
+
+    async handleSignInCallback(params: URLSearchParams): Promise<Response> {
+        try {
+            const oauthClient = await this.#getOAuthClient();
+            const {session: oauthSession} = await oauthClient.callback(params);
+
+            const agent = await createSkyAgent(oauthClient, oauthSession.did);
+            const profile = await agent.getProfile({actor: oauthSession.did});
+            const handle = profile.data.handle;
+
+            let session = await this.#kv.getSessionByDid(oauthSession.did);
+            if (session) {
+                session = await this.#kv.updateSessionProfile(session, handle);
+            } else {
+                session = {
+                    sessionId: crypto.randomUUID(),
+                    feedId: crypto.randomUUID(),
+                    did: oauthSession.did,
+                    handle,
+                };
+                await this.#kv.putSession(session);
+            }
+
+            this.#cookies.set(
+                SESSION_COOKIE_NAME,
+                session.sessionId,
+                SESSION_COOKIE_OPTIONS
+            );
+        } catch (error) {
+            console.error("Sky Feeder sign-in callback failed", {
+                oauthError: sanitizeLogString(params.get("error")),
+                message: errorMessage(error),
+            });
+            throw error;
+        }
+
+        return redirect(302, "/sky-feeder");
+    }
+
+    async handleSignOut(): Promise<Redirect> {
+        this.clearSessionCookie();
+        return redirect(302, "/sky-feeder");
+    }
+
+    clearSessionCookie(): void {
+        this.#cookies.delete(SESSION_COOKIE_NAME, SESSION_COOKIE_OPTIONS);
+    }
+
+    async handleResetFeedId(): Promise<Redirect> {
+        const session = await this.getSession();
+        if (!session) {
+            return redirect(302, "/sky-feeder");
+        }
+
+        await this.#kv.updateSessionFeedId(session, crypto.randomUUID());
+        return redirect(302, "/sky-feeder");
+    }
+
+    async handleUpdatePrefs(prefs: SkyFeederPrefs): Promise<Redirect> {
+        const session = await this.getSession();
+        if (!session) {
+            return redirect(302, "/sky-feeder");
+        }
+
+        await this.#kv.updateSessionPrefs(session, prefs);
+        return redirect(302, "/sky-feeder");
+    }
+
+    async handleTimelineFeed(
+        feedId: string,
+        options: FeedOptions
+    ): Promise<Response> {
+        const session = await this.#kv.getSessionByFeedId(feedId);
+        if (!session) {
+            return new Response("Unknown feed ID", {status: 404});
+        }
+
+        const prefs = resolveFeederPrefs(session.prefs);
+        try {
+            const agent = await this.#getAgent(session.did);
+            return feedOutputResponse(
+                await renderTimelineFeed(
+                    agent,
+                    session,
+                    this.timelineFeedUrl(session, options.output),
+                    this.#baseUrl(),
+                    {timeZone: prefs.timeZone},
+                    options
+                )
+            );
+        } catch (error) {
+            if (isOAuthSessionUnavailable(error)) {
+                const message =
+                    "Sky Feeder authorization expired. Sign in again at /sky-feeder to restore this feed URL.";
+                console.error("Sky Feeder feed authorization failed", {
+                    did: session.did,
+                    handle: session.handle,
+                    message: errorMessage(error),
+                });
+                return options.output === "json"
+                    ? jsonResponse({message}, {status: 401})
+                    : new Response(message, {status: 401});
+            }
+            throw error;
+        }
+    }
+
+    async handleOAuthClientMetadata(): Promise<Response> {
+        return jsonResponse(skyClientMetadata(this.#baseUrl()));
+    }
+
+    async handleJwks(): Promise<Response> {
+        return jsonResponse(await skyJwks(parsePrivateJwk(this.#privateJwk)));
+    }
+
+    timelineFeedUrl(
+        session: SkyFeederSession,
+        output?: FeedOutputType
+    ): string {
+        const url = new URL(
+            `${this.#baseUrl()}/feed/${session.feedId}/timeline`
+        );
+        if (output && output !== "atom") {
+            url.searchParams.set("output", output);
+        }
+        return url.toString();
+    }
+
+    async #getAgent(did: string) {
+        return createSkyAgent(await this.#getOAuthClient(), did);
+    }
+
+    async #getOAuthClient() {
+        return createSkyOAuthClient({
+            baseUrl: this.#baseUrl(),
+            stateStore: this.#kv.oauthStateStore(),
+            sessionStore: this.#kv.oauthSessionStore(),
+            privateJwk: parsePrivateJwk(this.#privateJwk),
+        });
+    }
+
+    #baseUrl(): string {
+        return `${this.#appProtocol}//${this.#appHost}/sky-feeder`;
+    }
+}
+
+export function resolvePrefs(
+    prefs: SkyFeederPrefs | undefined
+): Required<SkyFeederPrefs> {
+    return resolveFeederPrefs(prefs);
+}
+
+export function isOAuthSessionUnavailable(error: unknown): boolean {
+    const message = errorMessage(error);
+    return (
+        message === "The session was deleted by another process" ||
+        message === "The session was revoked" ||
+        message === "Invalid refresh token" ||
+        message === "No refresh token available"
+    );
+}

--- a/worker/src/lib/sky-feeder/controller.ts
+++ b/worker/src/lib/sky-feeder/controller.ts
@@ -78,22 +78,32 @@ export class SkyFeederController {
     }
 
     async handleSignInCallback(params: URLSearchParams): Promise<Response> {
+        const oauthClient = await this.#getOAuthClient("callback");
+        let did: string;
         try {
-            const oauthClient = await this.#getOAuthClient("callback");
             const {session: oauthSession} = await oauthClient.callback(params);
+            did = oauthSession.did;
+        } catch (error) {
+            console.error("Sky Feeder sign-in callback failed", {
+                oauthError: sanitizeLogString(params.get("error")),
+                message: errorMessage(error),
+            });
+            return redirect(302, "/sky-feeder?auth_error=sign_in_failed");
+        }
 
-            const agent = await createSkyAgent(oauthClient, oauthSession.did);
-            const profile = await agent.getProfile({actor: oauthSession.did});
+        try {
+            const agent = await createSkyAgent(oauthClient, did);
+            const profile = await agent.getProfile({actor: did});
             const handle = profile.data.handle;
 
-            let session = await this.#kv.getSessionByDid(oauthSession.did);
+            let session = await this.#kv.getSessionByDid(did);
             if (session) {
                 session = await this.#kv.updateSessionProfile(session, handle);
             } else {
                 session = {
                     sessionId: crypto.randomUUID(),
                     feedId: crypto.randomUUID(),
-                    did: oauthSession.did,
+                    did,
                     handle,
                 };
                 await this.#kv.putSession(session);
@@ -105,8 +115,7 @@ export class SkyFeederController {
                 SESSION_COOKIE_OPTIONS
             );
         } catch (error) {
-            console.error("Sky Feeder sign-in callback failed", {
-                oauthError: sanitizeLogString(params.get("error")),
+            console.error("Sky Feeder sign-in session setup failed", {
                 message: errorMessage(error),
             });
             throw error;

--- a/worker/src/lib/sky-feeder/controller.ts
+++ b/worker/src/lib/sky-feeder/controller.ts
@@ -4,7 +4,7 @@ import {
     type Redirect,
     type RequestEvent,
 } from "@sveltejs/kit";
-import {errorMessage, sanitizeLogString} from "$lib/feeder/log";
+import {errorMessage, errorSummary, sanitizeLogString} from "$lib/feeder/log";
 import {feedOutputResponse, jsonResponse} from "$lib/feeder/response";
 import {resolveFeederPrefs} from "$lib/feeder/prefs";
 import {WorkerKV} from "$lib/kv";
@@ -53,7 +53,7 @@ export class SkyFeederController {
     }
 
     async getProfile(session: SkyFeederSession) {
-        const agent = await this.#getAgent(session.did);
+        const agent = await this.#getAgent(session.did, "profile");
         const profile = await agent.getProfile({actor: session.did});
         return profile.data;
     }
@@ -61,7 +61,7 @@ export class SkyFeederController {
     async handleSignIn(handle: string): Promise<Redirect> {
         let authUrl: URL;
         try {
-            const oauthClient = await this.#getOAuthClient();
+            const oauthClient = await this.#getOAuthClient("sign-in");
             authUrl = await oauthClient.authorize(handle, {
                 scope: OAUTH_SCOPE,
                 state: crypto.randomUUID(),
@@ -79,7 +79,7 @@ export class SkyFeederController {
 
     async handleSignInCallback(params: URLSearchParams): Promise<Response> {
         try {
-            const oauthClient = await this.#getOAuthClient();
+            const oauthClient = await this.#getOAuthClient("callback");
             const {session: oauthSession} = await oauthClient.callback(params);
 
             const agent = await createSkyAgent(oauthClient, oauthSession.did);
@@ -155,7 +155,21 @@ export class SkyFeederController {
 
         const prefs = resolveFeederPrefs(session.prefs);
         try {
-            const agent = await this.#getAgent(session.did);
+            console.info("sky-feeder:feed-auth", {
+                step: "restore:start",
+                did: session.did,
+                handle: session.handle,
+                appHost: this.#appHost,
+                appProtocol: this.#appProtocol,
+            });
+            const agent = await this.#getAgent(session.did, "feed");
+            console.info("sky-feeder:feed-auth", {
+                step: "restore:success",
+                did: session.did,
+                handle: session.handle,
+                appHost: this.#appHost,
+                appProtocol: this.#appProtocol,
+            });
             return feedOutputResponse(
                 await renderTimelineFeed(
                     agent,
@@ -173,7 +187,10 @@ export class SkyFeederController {
                 console.error("Sky Feeder feed authorization failed", {
                     did: session.did,
                     handle: session.handle,
+                    appHost: this.#appHost,
+                    appProtocol: this.#appProtocol,
                     message: errorMessage(error),
+                    error: errorSummary(error),
                 });
                 return options.output === "json"
                     ? jsonResponse({message}, {status: 401})
@@ -204,15 +221,15 @@ export class SkyFeederController {
         return url.toString();
     }
 
-    async #getAgent(did: string) {
-        return createSkyAgent(await this.#getOAuthClient(), did);
+    async #getAgent(did: string, context: string) {
+        return createSkyAgent(await this.#getOAuthClient(context), did);
     }
 
-    async #getOAuthClient() {
+    async #getOAuthClient(context: string) {
         return createSkyOAuthClient({
             baseUrl: this.#baseUrl(),
             stateStore: this.#kv.oauthStateStore(),
-            sessionStore: this.#kv.oauthSessionStore(),
+            sessionStore: this.#kv.oauthSessionStore(context),
             privateJwk: parsePrivateJwk(this.#privateJwk),
         });
     }

--- a/worker/src/lib/sky-feeder/feed.ts
+++ b/worker/src/lib/sky-feeder/feed.ts
@@ -1,0 +1,119 @@
+import {APP_NAME} from "$lib/constants";
+import {renderFeed, type FeedOptions, type FeedOutput} from "$lib/status/feed";
+import {AppBskyFeedDefs, type Agent} from "@atproto/api";
+import type {SkyFeederSession} from "./types";
+import {toStatus, type BlueskyAdapterEnv} from "./status-adapter";
+
+export async function renderTimelineFeed(
+    agent: Agent,
+    session: SkyFeederSession,
+    feedUrl: string,
+    homeUrl: string,
+    env: BlueskyAdapterEnv,
+    options: FeedOptions = {}
+): Promise<FeedOutput> {
+    const profile = await agent.getProfile({actor: session.did});
+    const handle = profile.data.handle;
+    const title = `@${handle} Bluesky Timeline`;
+    const updatedDate = new Date();
+    const authorName = `${APP_NAME} : Sky Feeder`;
+
+    const posts = await fetchRecentTimelinePosts(agent, session.did, options);
+    const statuses = posts.map(post => toStatus(post, env));
+
+    return renderFeed(
+        statuses,
+        {
+            feedUrl,
+            homeUrl,
+            title,
+            updatedDate,
+            authorName,
+        },
+        options
+    );
+}
+
+async function fetchRecentTimelinePosts(
+    agent: Agent,
+    viewerDid: string,
+    options: FeedOptions
+): Promise<AppBskyFeedDefs.FeedViewPost[]> {
+    const limitTime = Date.now() - 12 * 60 * 60 * 1000;
+    const posts: AppBskyFeedDefs.FeedViewPost[] = [];
+    const eventKeys = new Set<string>();
+    const cursors = new Set<string>();
+    let cursor: string | undefined;
+
+    while (true) {
+        const response = await agent.getTimeline({
+            limit: options.debug ? 10 : 50,
+            cursor,
+        });
+        const freshPosts = response.data.feed.filter(item => {
+            const eventTime = timelineEventTimeMillis(item);
+            return eventTime >= limitTime;
+        });
+        if (freshPosts.length === 0) {
+            break;
+        }
+
+        const newPosts = freshPosts.filter(item => {
+            const key = timelineEventKey(item);
+            if (eventKeys.has(key)) {
+                return false;
+            }
+            eventKeys.add(key);
+            return true;
+        });
+        const visiblePosts = newPosts.filter(item =>
+            shouldIncludeTimelinePost(item, viewerDid)
+        );
+        posts.push(...visiblePosts);
+
+        const nextCursor = response.data.cursor;
+        if (!nextCursor || options.debug || cursors.has(nextCursor)) {
+            break;
+        }
+        cursors.add(nextCursor);
+        cursor = nextCursor;
+    }
+
+    return posts;
+}
+
+function shouldIncludeTimelinePost(
+    item: AppBskyFeedDefs.FeedViewPost,
+    viewerDid: string
+): boolean {
+    const parent = item.reply?.parent;
+    if (!parent) {
+        return true;
+    }
+    if (!AppBskyFeedDefs.isPostView(parent)) {
+        return false;
+    }
+
+    const parentDid = parent.author.did;
+    const authorDid = item.post.author.did;
+    return (
+        parentDid === authorDid ||
+        parentDid === viewerDid ||
+        Boolean(parent.author.viewer?.following)
+    );
+}
+
+function timelineEventKey(item: AppBskyFeedDefs.FeedViewPost): string {
+    if (AppBskyFeedDefs.isReasonRepost(item.reason)) {
+        return `${item.post.uri}#repost:${item.reason.by.did}:${item.reason.indexedAt}`;
+    }
+    return `${item.post.uri}#post:${item.post.indexedAt}`;
+}
+
+function timelineEventTimeMillis(item: AppBskyFeedDefs.FeedViewPost): number {
+    const eventTime = AppBskyFeedDefs.isReasonRepost(item.reason)
+        ? item.reason.indexedAt
+        : item.post.indexedAt;
+    const millis = new Date(eventTime).getTime();
+    return Number.isFinite(millis) ? millis : 0;
+}

--- a/worker/src/lib/sky-feeder/kv.ts
+++ b/worker/src/lib/sky-feeder/kv.ts
@@ -93,20 +93,27 @@ export class SkyFeederKV {
         };
     }
 
-    oauthSessionStore() {
+    oauthSessionStore(context: string) {
         return {
             set: async (
                 did: string,
                 value: NodeSavedSession
             ): Promise<void> => {
+                logOAuthSession(context, "set", did, value);
                 await this.#kv.putJSON(this.#oauthSessionKey(did), value);
             },
             get: async (did: string): Promise<NodeSavedSession | undefined> => {
-                return (
+                const value =
                     (await this.#kv.getJSON<NodeSavedSession>(
                         this.#oauthSessionKey(did)
-                    )) ?? undefined
+                    )) ?? undefined;
+                logOAuthSession(
+                    context,
+                    value ? "get:hit" : "get:miss",
+                    did,
+                    value
                 );
+                return value;
             },
             // Refresh tokens are single-use, and feeds may be fetched by
             // multiple Worker isolates at once. The ATProto client asks the
@@ -114,7 +121,13 @@ export class SkyFeederKV {
             // cannot do a compare-and-delete, so a losing isolate can delete a
             // newer token set written by a winning isolate. Keep the session
             // and let future requests observe the latest KV value.
-            del: async (): Promise<void> => {},
+            del: async (did: string): Promise<void> => {
+                console.info("sky-feeder:oauth-session", {
+                    context,
+                    step: "del:ignored",
+                    did,
+                });
+            },
         };
     }
 
@@ -137,4 +150,69 @@ export class SkyFeederKV {
     #oauthSessionKey(did: string): string {
         return `${PREFIX}:oauth_session:${did}`;
     }
+}
+
+function logOAuthSession(
+    context: string,
+    step: string,
+    did: string,
+    session: NodeSavedSession | undefined
+): void {
+    console.info("sky-feeder:oauth-session", {
+        context,
+        step,
+        did,
+        session: session ? oauthSessionSummary(session) : null,
+    });
+}
+
+function oauthSessionSummary(session: NodeSavedSession) {
+    const expiresAt = tokenExpiryDate(session.tokenSet.expires_at);
+    return {
+        topLevelKeys: Object.keys(session).sort(),
+        tokenSet: {
+            aud: session.tokenSet.aud,
+            sub: session.tokenSet.sub,
+            iss: session.tokenSet.iss,
+            scope: session.tokenSet.scope,
+            expires_at: session.tokenSet.expires_at,
+            expiresAtIso: expiresAt?.toISOString(),
+            secondsUntilExpiry: expiresAt
+                ? Math.round((expiresAt.getTime() - Date.now()) / 1000)
+                : undefined,
+            hasAccessToken: Boolean(session.tokenSet.access_token),
+            hasRefreshToken: Boolean(session.tokenSet.refresh_token),
+        },
+        hasDpopJwk: Boolean(
+            "dpopJwk" in session &&
+            (session as unknown as {dpopJwk?: unknown}).dpopJwk
+        ),
+        hasDpopKey: Boolean(
+            "dpopKey" in session &&
+            (session as unknown as {dpopKey?: unknown}).dpopKey
+        ),
+        authMethod: {
+            method: session.authMethod.method,
+            kid:
+                "kid" in session.authMethod
+                    ? (session.authMethod as {kid?: string}).kid
+                    : undefined,
+        },
+    };
+}
+
+function tokenExpiryDate(expiresAt: unknown): Date | undefined {
+    if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+        return new Date(expiresAt * 1000);
+    }
+    if (typeof expiresAt === "string") {
+        const numericExpiresAt = Number(expiresAt);
+        const date = Number.isFinite(numericExpiresAt)
+            ? new Date(numericExpiresAt * 1000)
+            : new Date(expiresAt);
+        if (Number.isFinite(date.getTime())) {
+            return date;
+        }
+    }
+    return undefined;
 }

--- a/worker/src/lib/sky-feeder/kv.ts
+++ b/worker/src/lib/sky-feeder/kv.ts
@@ -1,0 +1,140 @@
+import type {KV} from "$lib/kv";
+import type {
+    NodeSavedSession,
+    NodeSavedState,
+} from "@atproto/oauth-client-node";
+import type {SkyFeederPrefs, SkyFeederSession} from "./types";
+
+const PREFIX = "sky-feeder";
+const OAUTH_STATE_TTL_SECONDS = 60 * 60;
+
+export class SkyFeederKV {
+    #kv: KV;
+
+    constructor(kv: KV) {
+        this.#kv = kv;
+    }
+
+    async getSessionById(id: string): Promise<SkyFeederSession | null> {
+        return this.#kv.getJSON(this.#sessionKey(id));
+    }
+
+    async getSessionByFeedId(feedId: string): Promise<SkyFeederSession | null> {
+        const sessionId = await this.#kv.get(this.#sessionFeedIdKey(feedId));
+        if (!sessionId) {
+            return null;
+        }
+        return await this.getSessionById(sessionId);
+    }
+
+    async getSessionByDid(did: string): Promise<SkyFeederSession | null> {
+        const sessionId = await this.#kv.get(this.#sessionDidKey(did));
+        if (!sessionId) {
+            return null;
+        }
+        return await this.getSessionById(sessionId);
+    }
+
+    async putSession(session: SkyFeederSession): Promise<void> {
+        await this.#kv.put(
+            this.#sessionFeedIdKey(session.feedId),
+            session.sessionId
+        );
+        await this.#kv.put(this.#sessionDidKey(session.did), session.sessionId);
+        await this.#kv.putJSON(this.#sessionKey(session.sessionId), session);
+    }
+
+    async updateSessionProfile(
+        session: SkyFeederSession,
+        handle: string
+    ): Promise<SkyFeederSession> {
+        session.handle = handle;
+        await this.#kv.putJSON(this.#sessionKey(session.sessionId), session);
+        return session;
+    }
+
+    async updateSessionFeedId(
+        session: SkyFeederSession,
+        feedId: string
+    ): Promise<SkyFeederSession> {
+        await this.#kv.delete(this.#sessionFeedIdKey(session.feedId));
+        session.feedId = feedId;
+        await this.#kv.putJSON(this.#sessionKey(session.sessionId), session);
+        await this.#kv.put(this.#sessionFeedIdKey(feedId), session.sessionId);
+        return session;
+    }
+
+    async updateSessionPrefs(
+        session: SkyFeederSession,
+        prefs: SkyFeederPrefs
+    ): Promise<SkyFeederSession> {
+        session.prefs = prefs;
+        await this.#kv.putJSON(this.#sessionKey(session.sessionId), session);
+        return session;
+    }
+
+    oauthStateStore() {
+        return {
+            set: async (key: string, value: NodeSavedState): Promise<void> => {
+                await this.#kv.putJSON(this.#oauthStateKey(key), value, {
+                    expirationTtl: OAUTH_STATE_TTL_SECONDS,
+                });
+            },
+            get: async (key: string): Promise<NodeSavedState | undefined> => {
+                return (
+                    (await this.#kv.getJSON<NodeSavedState>(
+                        this.#oauthStateKey(key)
+                    )) ?? undefined
+                );
+            },
+            del: async (key: string): Promise<void> => {
+                await this.#kv.delete(this.#oauthStateKey(key));
+            },
+        };
+    }
+
+    oauthSessionStore() {
+        return {
+            set: async (
+                did: string,
+                value: NodeSavedSession
+            ): Promise<void> => {
+                await this.#kv.putJSON(this.#oauthSessionKey(did), value);
+            },
+            get: async (did: string): Promise<NodeSavedSession | undefined> => {
+                return (
+                    (await this.#kv.getJSON<NodeSavedSession>(
+                        this.#oauthSessionKey(did)
+                    )) ?? undefined
+                );
+            },
+            // Refresh tokens are single-use, and feeds may be fetched by
+            // multiple Worker isolates at once. The ATProto client asks the
+            // store to delete a session after some refresh failures, but KV
+            // cannot do a compare-and-delete, so a losing isolate can delete a
+            // newer token set written by a winning isolate. Keep the session
+            // and let future requests observe the latest KV value.
+            del: async (): Promise<void> => {},
+        };
+    }
+
+    #sessionKey(id: string): string {
+        return `${PREFIX}:session:${id}`;
+    }
+
+    #sessionFeedIdKey(id: string): string {
+        return `${PREFIX}:session_feed_id:${id}`;
+    }
+
+    #sessionDidKey(did: string): string {
+        return `${PREFIX}:session_did:${did}`;
+    }
+
+    #oauthStateKey(id: string): string {
+        return `${PREFIX}:oauth_state:${id}`;
+    }
+
+    #oauthSessionKey(did: string): string {
+        return `${PREFIX}:oauth_session:${did}`;
+    }
+}

--- a/worker/src/lib/sky-feeder/oauth.ts
+++ b/worker/src/lib/sky-feeder/oauth.ts
@@ -1,0 +1,262 @@
+import {APP_NAME} from "$lib/constants";
+import {Agent} from "@atproto/api";
+import {
+    AtprotoHandleResolver,
+    type ResolveTxt,
+} from "@atproto-labs/handle-resolver";
+import type {
+    AtprotoIdentityDidMethods,
+    DidResolver,
+    ResolveDidOptions,
+    ResolvedDocument,
+} from "@atproto-labs/did-resolver";
+import {
+    assertDidPlc,
+    assertDidWeb,
+    didDocumentValidator,
+    didWebToUrl,
+    extractDidMethod,
+    type Did,
+} from "@atproto/did";
+import {
+    JoseKey,
+    NodeOAuthClient,
+    type OAuthClientMetadataInput,
+    requestLocalLock,
+    type NodeSavedSessionStore,
+    type NodeSavedStateStore,
+} from "@atproto/oauth-client-node";
+import {resolveTxt} from "node:dns/promises";
+
+const BSKY_APPVIEW_AUDIENCE = "did:web:api.bsky.app#bsky_appview";
+
+export const OAUTH_SCOPE = [
+    "atproto",
+    bskyAppViewScope("app.bsky.actor.getProfile"),
+    bskyAppViewScope("app.bsky.feed.getTimeline"),
+].join(" ");
+
+export async function createSkyOAuthClient({
+    baseUrl,
+    stateStore,
+    sessionStore,
+    privateJwk,
+}: SkyOAuthClientOptions): Promise<NodeOAuthClient> {
+    const keyId =
+        typeof privateJwk.kid === "string" ? privateJwk.kid : "default";
+    const key = await JoseKey.fromJWK(privateJwk, keyId);
+    return new NodeOAuthClient({
+        clientMetadata: skyClientMetadata(baseUrl),
+        keyset: [key],
+        stateStore,
+        sessionStore,
+        responseMode: "query",
+        allowHttp: baseUrl.startsWith("http://"),
+        requestLock: requestLocalLock,
+        handleResolver: createWorkerHandleResolver(),
+        didResolver: createWorkerDidResolver(),
+        fetch: oauthFetch,
+    });
+}
+
+export function skyClientMetadata(baseUrl: string): OAuthClientMetadataInput {
+    return {
+        client_id: `${baseUrl}/oauth-client-metadata.json`,
+        client_name: `${APP_NAME} - Sky Feeder`,
+        client_uri: baseUrl,
+        redirect_uris: [`${baseUrl}/sign-in-callback`],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        application_type: "web",
+        scope: OAUTH_SCOPE,
+        token_endpoint_auth_method: "private_key_jwt",
+        token_endpoint_auth_signing_alg: "ES256",
+        dpop_bound_access_tokens: true,
+        jwks_uri: `${baseUrl}/jwks.json`,
+    };
+}
+
+export async function skyJwks(privateJwk: Record<string, unknown>) {
+    const keyId =
+        typeof privateJwk.kid === "string" ? privateJwk.kid : "default";
+    const key = await JoseKey.fromJWK(privateJwk, keyId);
+    return {keys: [key.publicJwk]};
+}
+
+export async function createSkyAgent(
+    oauthClient: NodeOAuthClient,
+    did: string
+): Promise<Agent> {
+    const oauthSession = await oauthClient.restore(did);
+    return new Agent(oauthSession);
+}
+
+export type SkyOAuthClientOptions = {
+    baseUrl: string;
+    stateStore: NodeSavedStateStore;
+    sessionStore: NodeSavedSessionStore;
+    privateJwk: Record<string, unknown>;
+};
+
+export function parsePrivateJwk(
+    rawJwk: string | undefined
+): Record<string, unknown> {
+    if (!rawJwk) {
+        throw new Error("ATPROTO_OAUTH_PRIVATE_JWK is not configured");
+    }
+    const jwk = JSON.parse(rawJwk);
+    if (!jwk || typeof jwk !== "object") {
+        throw new Error("ATPROTO_OAUTH_PRIVATE_JWK is not a JSON object");
+    }
+    return jwk as Record<string, unknown>;
+}
+
+function bskyAppViewScope(method: string): string {
+    return `rpc:${method}?aud=${BSKY_APPVIEW_AUDIENCE.replace("#", "%23")}`;
+}
+
+async function oauthFetch(
+    input: string | URL | Request,
+    init?: RequestInit
+): Promise<Response> {
+    const request = workerSafeFetchRequest(input, init);
+    const response = await fetch.call(null, request.input, request.init);
+    if (request.rejectRedirect && isRedirect(response.status)) {
+        await response.body?.cancel();
+        throw new TypeError(
+            `Fetch received redirect response ${response.status} with redirect mode "error"`
+        );
+    }
+    return response;
+}
+
+function workerSafeFetchRequest(
+    input: string | URL | Request,
+    init?: RequestInit
+): WorkerSafeFetchRequest {
+    const request = normalizeRequest(input, init);
+    if (request.init?.cache === "no-cache") {
+        const headers = new Headers(request.init.headers);
+        if (!headers.has("cache-control")) {
+            headers.set("cache-control", "no-cache");
+        }
+        request.init = {
+            ...request.init,
+            cache: undefined,
+            headers,
+        };
+    }
+    return request;
+}
+
+function normalizeRequest(
+    input: string | URL | Request,
+    init?: RequestInit
+): WorkerSafeFetchRequest {
+    if (init?.redirect === "error") {
+        return {
+            input,
+            init: {...init, redirect: "manual"},
+            rejectRedirect: true,
+        };
+    }
+
+    if (input instanceof Request && input.redirect === "error") {
+        return {
+            input: new Request(input, {
+                ...init,
+                redirect: "manual",
+            }),
+            init: undefined,
+            rejectRedirect: true,
+        };
+    }
+
+    return {
+        input,
+        init,
+        rejectRedirect: false,
+    };
+}
+
+function isRedirect(status: number): boolean {
+    return status >= 300 && status < 400;
+}
+
+type WorkerSafeFetchRequest = {
+    input: string | URL | Request;
+    init: RequestInit | undefined;
+    rejectRedirect: boolean;
+};
+
+function createWorkerHandleResolver(): AtprotoHandleResolver {
+    return new AtprotoHandleResolver({
+        fetch: oauthFetch,
+        resolveTxt: workerResolveTxt,
+    });
+}
+
+function createWorkerDidResolver(): DidResolver<AtprotoIdentityDidMethods> {
+    return {
+        resolve: resolveWorkerDid,
+    };
+}
+
+async function resolveWorkerDid<D extends Did>(
+    did: D,
+    options?: ResolveDidOptions
+): Promise<ResolvedDocument<D, AtprotoIdentityDidMethods>> {
+    options?.signal?.throwIfAborted();
+
+    const url = didDocumentUrl(did);
+    const response = await oauthFetch(url, {
+        redirect: "error",
+        headers: {accept: "application/did+ld+json,application/json"},
+        signal: options?.signal,
+    });
+
+    if (!response.ok) {
+        throw new Error(
+            `DID document fetch failed with HTTP status ${response.status}`
+        );
+    }
+
+    const document = didDocumentValidator.parse(await response.json());
+    if (document.id !== did) {
+        throw new Error(`DID document id (${document.id}) does not match DID`);
+    }
+
+    return document as ResolvedDocument<D, AtprotoIdentityDidMethods>;
+}
+
+function didDocumentUrl(did: Did): URL {
+    const method = extractDidMethod(did);
+    if (method === "plc") {
+        assertDidPlc(did);
+        return new URL(`/${encodeURIComponent(did)}`, "https://plc.directory/");
+    }
+
+    if (method === "web") {
+        assertDidWeb(did);
+        return didWebDocumentUrl(did);
+    }
+
+    throw new Error(`Unsupported DID method "${method}"`);
+}
+
+function didWebDocumentUrl(did: Did<"web">): URL {
+    const url = didWebToUrl(did);
+    if (url.pathname === "/") {
+        return new URL("/.well-known/did.json", url);
+    }
+    return new URL(`${url.pathname}/did.json`, url);
+}
+
+const workerResolveTxt: ResolveTxt = async hostname => {
+    try {
+        const records = await resolveTxt(hostname);
+        return records.map(chunks => chunks.join(""));
+    } catch {
+        return null;
+    }
+};

--- a/worker/src/lib/sky-feeder/status-adapter.ts
+++ b/worker/src/lib/sky-feeder/status-adapter.ts
@@ -242,7 +242,7 @@ function facetAsHtml(text: string, facet: AppBskyRichtextFacet.Main): string {
 
     let href: string | null = null;
     if (AppBskyRichtextFacet.isLink(feature)) {
-        href = safeFacetHref(feature.uri);
+        href = safeHttpUrl(feature.uri);
     } else if (AppBskyRichtextFacet.isMention(feature)) {
         href = `${BLUESKY_APP_URL}/profile/${feature.did}`;
     } else if (AppBskyRichtextFacet.isTag(feature)) {
@@ -254,7 +254,7 @@ function facetAsHtml(text: string, facet: AppBskyRichtextFacet.Main): string {
         : escapeHtml(text);
 }
 
-function safeFacetHref(uri: string): string | null {
+function safeHttpUrl(uri: string): string | null {
     try {
         const url = new URL(uri);
         return url.protocol === "http:" || url.protocol === "https:"
@@ -321,8 +321,12 @@ function cardFromEmbeds(
 ): StatusCard | null {
     for (const embed of embeds) {
         if (AppBskyEmbedExternal.isView(embed)) {
+            const url = safeHttpUrl(embed.external.uri);
+            if (!url) {
+                continue;
+            }
             return {
-                url: embed.external.uri,
+                url,
                 title: embed.external.title,
                 description: embed.external.description,
                 imageUrl: embed.external.thumb,

--- a/worker/src/lib/sky-feeder/status-adapter.ts
+++ b/worker/src/lib/sky-feeder/status-adapter.ts
@@ -1,0 +1,389 @@
+import type {
+    Status,
+    StatusAccount,
+    StatusAttachment,
+    StatusCard,
+} from "$lib/status";
+import {escapeHtml, escapeHtmlAttribute} from "$lib/html";
+import {truncate} from "$lib/strings";
+import {
+    AppBskyEmbedExternal,
+    AppBskyEmbedImages,
+    AppBskyEmbedRecord,
+    AppBskyEmbedRecordWithMedia,
+    AppBskyEmbedVideo,
+    AppBskyFeedDefs,
+    AppBskyFeedPost,
+    AppBskyRichtextFacet,
+    ComAtprotoLabelDefs,
+} from "@atproto/api";
+
+const BLUESKY_APP_URL = "https://bsky.app";
+
+export type BlueskyAdapterEnv = {
+    timeZone: string;
+};
+
+export function toStatus(
+    feedPost: AppBskyFeedDefs.FeedViewPost,
+    env: BlueskyAdapterEnv
+): Status {
+    const repostReason = AppBskyFeedDefs.isReasonRepost(feedPost.reason)
+        ? feedPost.reason
+        : null;
+    const originalStatus = {
+        ...toStatusFromPost(feedPost.post, env),
+        parentUrl: parentUrl(feedPost),
+    };
+    if (!repostReason) {
+        return originalStatus;
+    }
+
+    return {
+        ...originalStatus,
+        id: `${feedPost.post.uri}#repost:${repostReason.by.did}:${repostReason.indexedAt}`,
+        author: toStatusAccount(repostReason.by),
+        createdAtIso: new Date(repostReason.indexedAt).toISOString(),
+        updatedAtIso: new Date(repostReason.indexedAt).toISOString(),
+        createdAtLabel: formatCreatedAt(repostReason.indexedAt, env),
+        titleText: `${displayName(repostReason.by)}: ↺ ${originalStatus.headlineText}`,
+        headlineText: `↺ ${originalStatus.headlineText}`,
+        contentHtml: "",
+        attachments: [],
+        poll: null,
+        card: null,
+        quote: null,
+        repost: {
+            by: toStatusAccount(repostReason.by),
+            status: originalStatus,
+            label: "reposted",
+        },
+        parentUrl: null,
+        debugJson: feedPost,
+    };
+}
+
+function toStatusFromPost(
+    post: AppBskyFeedDefs.PostView,
+    env: BlueskyAdapterEnv
+): Status {
+    const record = asPostRecord(post.record);
+    const createdAt = record?.createdAt ?? post.indexedAt;
+    const contentHtml = record
+        ? textWithFacetsAsHtml(record.text, record.facets)
+        : "";
+    const quote = quoteFromEmbed(post.embed, env);
+    const headlineText = headlineAsText(record?.text ?? "", quote);
+
+    return {
+        id: post.uri,
+        permalink: postUrl(post.uri, post.author.handle),
+        provider: "bluesky",
+        author: toStatusAccount(post.author),
+        createdAtIso: new Date(createdAt).toISOString(),
+        updatedAtIso: new Date(post.indexedAt).toISOString(),
+        createdAtLabel: formatCreatedAt(createdAt, env),
+        titleText: `${displayName(post.author)}: ${headlineText}`,
+        headlineText,
+        contentHtml,
+        spoilerText: record ? selfLabelSpoiler(record.labels) : undefined,
+        attachments: attachmentsFromEmbed(post.embed),
+        poll: null,
+        card: cardFromEmbed(post.embed),
+        quote,
+        repost: null,
+        applicationName: null,
+        parentUrl: null,
+        debugJson: post,
+    };
+}
+
+function toStatusFromRecordView(
+    recordView: AppBskyEmbedRecord.ViewRecord,
+    env: BlueskyAdapterEnv
+): Status {
+    const record = asPostRecord(recordView.value);
+    const createdAt = record?.createdAt ?? recordView.indexedAt;
+    const contentHtml = record
+        ? textWithFacetsAsHtml(record.text, record.facets)
+        : "";
+    const quote = quoteFromEmbeds(recordView.embeds ?? [], env);
+    const headlineText = headlineAsText(record?.text ?? "", quote);
+
+    return {
+        id: recordView.uri,
+        permalink: postUrl(recordView.uri, recordView.author.handle),
+        provider: "bluesky",
+        author: toStatusAccount(recordView.author),
+        createdAtIso: new Date(createdAt).toISOString(),
+        updatedAtIso: new Date(recordView.indexedAt).toISOString(),
+        createdAtLabel: formatCreatedAt(createdAt, env),
+        titleText: `${displayName(recordView.author)}: ${headlineText}`,
+        headlineText,
+        contentHtml,
+        spoilerText: record ? selfLabelSpoiler(record.labels) : undefined,
+        attachments: attachmentsFromEmbeds(recordView.embeds ?? []),
+        poll: null,
+        card: cardFromEmbeds(recordView.embeds ?? []),
+        quote,
+        repost: null,
+        applicationName: null,
+        parentUrl: null,
+        debugJson: recordView,
+    };
+}
+
+function toStatusAccount(
+    account: AppBskyFeedDefs.PostView["author"]
+): StatusAccount {
+    return {
+        displayName: displayName(account),
+        username: account.handle,
+        url: `${BLUESKY_APP_URL}/profile/${account.handle || account.did}`,
+        avatarUrl: account.avatar ?? "",
+    };
+}
+
+function displayName(account: AppBskyFeedDefs.PostView["author"]): string {
+    return account.displayName || account.handle;
+}
+
+type BlueskyPostRecord = {
+    text: string;
+    createdAt: string;
+    facets?: AppBskyRichtextFacet.Main[];
+    labels?: AppBskyFeedPost.Main["labels"];
+};
+
+function asPostRecord(record: unknown): BlueskyPostRecord | null {
+    if (
+        !record ||
+        typeof record !== "object" ||
+        !("$type" in record) ||
+        record.$type !== "app.bsky.feed.post" ||
+        !("text" in record) ||
+        typeof record.text !== "string" ||
+        !("createdAt" in record) ||
+        typeof record.createdAt !== "string"
+    ) {
+        return null;
+    }
+    return record as BlueskyPostRecord;
+}
+
+function postUrl(uri: string, handle: string): string {
+    const rkey = uri.split("/").at(-1);
+    return `${BLUESKY_APP_URL}/profile/${handle}/post/${rkey}`;
+}
+
+function parentUrl(feedPost: AppBskyFeedDefs.FeedViewPost): string | null {
+    const parent = feedPost.reply?.parent;
+    if (!AppBskyFeedDefs.isPostView(parent)) {
+        return null;
+    }
+    return postUrl(parent.uri, parent.author.handle);
+}
+
+function formatCreatedAt(createdAt: string, env: BlueskyAdapterEnv): string {
+    return new Intl.DateTimeFormat("en-US", {
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+        timeZone: env.timeZone,
+    }).format(new Date(createdAt));
+}
+
+function headlineAsText(text: string, quote: Status | null): string {
+    let headline = truncate(text.replace(/\s+/g, " ").trim());
+    if (!headline) {
+        headline = quote ? `Quoting ${quote.author.username}` : "Bluesky post";
+    } else if (quote) {
+        headline += ` (quoting ${quote.author.username})`;
+    }
+    return headline;
+}
+
+function textWithFacetsAsHtml(
+    text: string,
+    facets: AppBskyRichtextFacet.Main[] | undefined
+): string {
+    const bytes = new TextEncoder().encode(text);
+    const decoder = new TextDecoder();
+    const renderFacets = (facets ?? [])
+        .filter(facet => facet.index.byteEnd > facet.index.byteStart)
+        .sort((a, b) => a.index.byteStart - b.index.byteStart);
+
+    let result = "";
+    let cursor = 0;
+    for (const facet of renderFacets) {
+        const start = Math.max(0, facet.index.byteStart);
+        const end = Math.min(bytes.length, facet.index.byteEnd);
+        if (start < cursor || end <= start) {
+            continue;
+        }
+        result += escapeHtml(decoder.decode(bytes.slice(cursor, start)));
+        result += facetAsHtml(decoder.decode(bytes.slice(start, end)), facet);
+        cursor = end;
+    }
+    result += escapeHtml(decoder.decode(bytes.slice(cursor)));
+    return result.replace(/\n/g, "<br />");
+}
+
+function facetAsHtml(text: string, facet: AppBskyRichtextFacet.Main): string {
+    const feature = facet.features.find(
+        f =>
+            AppBskyRichtextFacet.isLink(f) ||
+            AppBskyRichtextFacet.isMention(f) ||
+            AppBskyRichtextFacet.isTag(f)
+    );
+    if (!feature) {
+        return escapeHtml(text);
+    }
+
+    let href: string | null = null;
+    if (AppBskyRichtextFacet.isLink(feature)) {
+        href = safeFacetHref(feature.uri);
+    } else if (AppBskyRichtextFacet.isMention(feature)) {
+        href = `${BLUESKY_APP_URL}/profile/${feature.did}`;
+    } else if (AppBskyRichtextFacet.isTag(feature)) {
+        href = `${BLUESKY_APP_URL}/hashtag/${encodeURIComponent(feature.tag)}`;
+    }
+
+    return href
+        ? `<a href="${escapeHtmlAttribute(href)}" rel="external">${escapeHtml(text)}</a>`
+        : escapeHtml(text);
+}
+
+function safeFacetHref(uri: string): string | null {
+    try {
+        const url = new URL(uri);
+        return url.protocol === "http:" || url.protocol === "https:"
+            ? url.toString()
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function attachmentsFromEmbed(
+    embed: AppBskyFeedDefs.PostView["embed"] | undefined
+): StatusAttachment[] {
+    return attachmentsFromEmbeds(embed ? [embed] : []);
+}
+
+function attachmentsFromEmbeds(
+    embeds: NonNullable<AppBskyEmbedRecord.ViewRecord["embeds"]>
+): StatusAttachment[] {
+    const attachments: StatusAttachment[] = [];
+    for (const embed of embeds) {
+        if (AppBskyEmbedImages.isView(embed)) {
+            attachments.push(...embed.images.map(toImageAttachment));
+        } else if (AppBskyEmbedVideo.isView(embed)) {
+            attachments.push(toVideoAttachment(embed));
+        } else if (AppBskyEmbedRecordWithMedia.isView(embed)) {
+            attachments.push(...attachmentsFromEmbeds([embed.media]));
+        }
+    }
+    return attachments;
+}
+
+function toImageAttachment(
+    image: AppBskyEmbedImages.ViewImage
+): StatusAttachment {
+    return {
+        id: image.fullsize,
+        type: "image",
+        url: image.fullsize,
+        previewUrl: image.thumb,
+        description: image.alt || "image",
+    };
+}
+
+function toVideoAttachment(video: AppBskyEmbedVideo.View): StatusAttachment {
+    return {
+        id: video.cid,
+        type: video.presentation === "gif" ? "gifv" : "video",
+        url: video.playlist,
+        previewUrl: video.thumbnail,
+        posterUrl: video.thumbnail,
+        description: video.alt || "video",
+    };
+}
+
+function cardFromEmbed(
+    embed: AppBskyFeedDefs.PostView["embed"] | undefined
+): StatusCard | null {
+    return cardFromEmbeds(embed ? [embed] : []);
+}
+
+function cardFromEmbeds(
+    embeds: NonNullable<AppBskyEmbedRecord.ViewRecord["embeds"]>
+): StatusCard | null {
+    for (const embed of embeds) {
+        if (AppBskyEmbedExternal.isView(embed)) {
+            return {
+                url: embed.external.uri,
+                title: embed.external.title,
+                description: embed.external.description,
+                imageUrl: embed.external.thumb,
+            };
+        }
+        if (AppBskyEmbedRecordWithMedia.isView(embed)) {
+            const card = cardFromEmbeds([embed.media]);
+            if (card) {
+                return card;
+            }
+        }
+    }
+    return null;
+}
+
+function quoteFromEmbed(
+    embed: AppBskyFeedDefs.PostView["embed"] | undefined,
+    env: BlueskyAdapterEnv
+): Status | null {
+    return quoteFromEmbeds(embed ? [embed] : [], env);
+}
+
+function quoteFromEmbeds(
+    embeds: NonNullable<AppBskyEmbedRecord.ViewRecord["embeds"]>,
+    env: BlueskyAdapterEnv
+): Status | null {
+    for (const embed of embeds) {
+        if (AppBskyEmbedRecord.isView(embed)) {
+            const quote = quoteFromRecordView(embed.record, env);
+            if (quote) {
+                return quote;
+            }
+        } else if (AppBskyEmbedRecordWithMedia.isView(embed)) {
+            const quote = quoteFromRecordView(embed.record.record, env);
+            if (quote) {
+                return quote;
+            }
+        }
+    }
+    return null;
+}
+
+function quoteFromRecordView(
+    record:
+        | AppBskyEmbedRecord.View["record"]
+        | AppBskyEmbedRecordWithMedia.View["record"]["record"],
+    env: BlueskyAdapterEnv
+): Status | null {
+    return AppBskyEmbedRecord.isViewRecord(record)
+        ? toStatusFromRecordView(record, env)
+        : null;
+}
+
+function selfLabelSpoiler(
+    labels: AppBskyFeedPost.Main["labels"] | undefined
+): string | undefined {
+    if (
+        !ComAtprotoLabelDefs.isSelfLabels(labels) ||
+        labels.values.length === 0
+    ) {
+        return undefined;
+    }
+    return labels.values.map(label => label.val).join(", ");
+}

--- a/worker/src/lib/sky-feeder/types.ts
+++ b/worker/src/lib/sky-feeder/types.ts
@@ -1,0 +1,11 @@
+import type {FeederPrefs} from "$lib/feeder/prefs";
+
+export type SkyFeederSession = {
+    sessionId: string;
+    did: string;
+    handle: string;
+    feedId: string;
+    prefs?: SkyFeederPrefs;
+};
+
+export type SkyFeederPrefs = FeederPrefs;

--- a/worker/src/lib/tweeter-feeder/feed.ts
+++ b/worker/src/lib/tweeter-feeder/feed.ts
@@ -1,4 +1,5 @@
 import {APP_NAME} from "$lib/constants";
+import {escapeHtml} from "$lib/html";
 import {renderFeed, type FeedOptions, type FeedOutput} from "$lib/status/feed";
 import type {TwitterFetchError, TwitterTimelineResult} from "./types";
 import {toStatus} from "./status-adapter";
@@ -74,8 +75,4 @@ function injectDebugNotice(
         notices.join(" ")
     )}</div>`;
     return body.replace("<body>", `<body>${noticeHtml}`);
-}
-
-function escapeHtml(s: string): string {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/worker/src/lib/tweeter-feeder/fetcher.ts
+++ b/worker/src/lib/tweeter-feeder/fetcher.ts
@@ -1,3 +1,4 @@
+import {errorMessage} from "$lib/feeder/log";
 import type {CachedValue, TweeterFeederKV} from "./kv";
 import type {
     TweeterFeederSession,
@@ -140,7 +141,7 @@ export class TwitterFetcher {
                     username: normalizedUsername,
                     ageSeconds: cacheAgeSeconds(cached),
                     tweetCount: cached.value.tweets.length,
-                    error: e,
+                    message: errorToMessage(e),
                 });
                 return {...cached.value, fromStaleCache: true};
             }
@@ -148,7 +149,7 @@ export class TwitterFetcher {
                 "Tweeter Feeder timeline fetch failed without cache",
                 {
                     username: normalizedUsername,
-                    error: e,
+                    message: errorToMessage(e),
                 }
             );
             throw e;
@@ -234,7 +235,7 @@ export class TwitterFetcher {
                         e instanceof TwitterGraphQLFetchError
                             ? e.cooldownSession
                             : false,
-                    error: e,
+                    message: errorToMessage(e),
                 });
                 if (
                     e instanceof TwitterGraphQLFetchError &&
@@ -252,13 +253,13 @@ export class TwitterFetcher {
         if (lastError instanceof Error) {
             console.error("All Tweeter Feeder session attempts failed", {
                 key,
-                error: lastError,
+                message: errorToMessage(lastError),
             });
             throw lastError;
         }
         console.error("All Tweeter Feeder session attempts failed", {
             key,
-            error: lastError,
+            message: errorToMessage(lastError),
         });
         throw new TwitterGraphQLFetchError("Twitter/X fetch failed");
     }
@@ -309,7 +310,7 @@ export class TwitterFetcher {
                 endpoint,
                 elapsedMs,
                 timedOut: abortController.signal.aborted,
-                error: e,
+                message: errorToMessage(e),
             });
             throw new TwitterGraphQLFetchError(
                 abortController.signal.aborted
@@ -421,17 +422,7 @@ export function fetchErrorForUsername(
 }
 
 export function errorToMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-    if (typeof error === "string") {
-        return error;
-    }
-    try {
-        return JSON.stringify(error);
-    } catch {
-        return String(error);
-    }
+    return errorMessage(error);
 }
 
 class TwitterGraphQLFetchError extends Error {

--- a/worker/src/lib/tweeter-feeder/status-adapter.ts
+++ b/worker/src/lib/tweeter-feeder/status-adapter.ts
@@ -12,6 +12,7 @@ import type {
     StatusCard,
     StatusPoll,
 } from "$lib/status";
+import {escapeHtml, escapeHtmlAttribute} from "$lib/html";
 import {truncate} from "$lib/strings";
 
 const TWITTER_BASE_URL = "https://twitter.com";
@@ -238,19 +239,11 @@ function linkHtml(
     {softBreakSlashes = false}: {softBreakSlashes?: boolean} = {}
 ): string {
     const labelHtml = escapeHtml(label);
-    return `<a href="${escapeAttribute(url)}" rel="external">${
+    return `<a href="${escapeHtmlAttribute(url)}" rel="external">${
         softBreakSlashes ? labelHtml.replaceAll("/", "/&#8203;") : labelHtml
     }</a>`;
 }
 
 function stripHtml(html: string): string {
     return html.replace(/<[^>]*>/g, "").trim();
-}
-
-function escapeHtml(s: string): string {
-    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function escapeAttribute(s: string): string {
-    return escapeHtml(s).replace(/"/g, "&quot;");
 }

--- a/worker/src/routes/+page.svelte
+++ b/worker/src/routes/+page.svelte
@@ -35,7 +35,11 @@
             <h2>Masto Feeder</h2>
             <p>Keep up with Mastodon posts in your favorite feed reader</p>
         </a>
-        <a href={resolve("/tweeter-feeder")} class="tool odd">
+        <a href={resolve("/sky-feeder")} class="tool odd">
+            <h2>Sky Feeder</h2>
+            <p>Keep up with Bluesky posts in your favorite feed reader</p>
+        </a>
+        <a href={resolve("/tweeter-feeder")} class="tool even">
             <h2>Tweeter Feeder</h2>
             <p>Follow public Twitter/X accounts in your favorite feed reader</p>
         </a>

--- a/worker/src/routes/sky-feeder/+layout.server.ts
+++ b/worker/src/routes/sky-feeder/+layout.server.ts
@@ -1,0 +1,8 @@
+import {SkyFeederController} from "$lib/sky-feeder/controller";
+
+export async function load(event) {
+    const controller = new SkyFeederController(event);
+    return {
+        session: (await controller.getSession()) ?? undefined,
+    };
+}

--- a/worker/src/routes/sky-feeder/+page.server.ts
+++ b/worker/src/routes/sky-feeder/+page.server.ts
@@ -1,0 +1,129 @@
+import {
+    SkyFeederController,
+    isOAuthSessionUnavailable,
+    resolvePrefs,
+} from "$lib/sky-feeder/controller";
+import {errorMessage} from "$lib/feeder/log";
+import {isValidHandle} from "@atproto/syntax";
+import {fail} from "@sveltejs/kit";
+
+const SUPPORTED_TIME_ZONES = new Set(Intl.supportedValuesOf("timeZone"));
+
+export async function load(event) {
+    const {session} = await event.parent();
+    if (!session) {
+        return;
+    }
+
+    const controller = new SkyFeederController(event);
+    let profile;
+    try {
+        profile = await controller.getProfile(session);
+    } catch (error) {
+        if (isOAuthSessionUnavailable(error)) {
+            controller.clearSessionCookie();
+            return {
+                session: undefined,
+                authError:
+                    "Sky Feeder authorization expired. Sign in with Bluesky again to reconnect your feed.",
+            };
+        }
+        throw error;
+    }
+    const prefs = resolvePrefs(session.prefs);
+
+    return {
+        profile,
+        prefs,
+        timelineFeedUrl: controller.timelineFeedUrl(session),
+        timelineJsonFeedUrl: controller.timelineFeedUrl(session, "json"),
+    };
+}
+
+export const actions = {
+    "sign-in": async event => {
+        const formData = await event.request.formData();
+        const rawHandle = formData.get("handle");
+        const handle = normalizeHandle(rawHandle);
+        const submittedHandle =
+            typeof rawHandle === "string" ? rawHandle : undefined;
+
+        if (!handle) {
+            return fail(400, {
+                handle: submittedHandle,
+                error: submittedHandle
+                    ? "Enter a valid Bluesky handle"
+                    : "Bluesky handle is required",
+            });
+        }
+
+        const controller = new SkyFeederController(event);
+        try {
+            return await controller.handleSignIn(handle);
+        } catch (error) {
+            if (isHandleResolutionError(error)) {
+                return fail(400, {
+                    handle: submittedHandle,
+                    error: `Could not resolve @${handle}. Check that the handle is spelled correctly.`,
+                });
+            }
+            throw error;
+        }
+    },
+    "sign-out": async event => {
+        const controller = new SkyFeederController(event);
+        return controller.handleSignOut();
+    },
+    "reset-feed-id": async event => {
+        const controller = new SkyFeederController(event);
+        return controller.handleResetFeedId();
+    },
+    "update-prefs": async event => {
+        const formData = await event.request.formData();
+        const timeZone = formData.get("time_zone") as string | null;
+        if (!timeZone) {
+            return fail(400, {
+                timezone: timeZone,
+                error: "Time zone is required",
+            });
+        }
+        if (!SUPPORTED_TIME_ZONES.has(timeZone)) {
+            return fail(400, {
+                timezone: timeZone,
+                error: "Time zone is invalid",
+            });
+        }
+
+        const controller = new SkyFeederController(event);
+        return controller.handleUpdatePrefs({timeZone});
+    },
+};
+
+function normalizeHandle(rawHandle: FormDataEntryValue | null): string | null {
+    if (typeof rawHandle !== "string") {
+        return null;
+    }
+    const handle = rawHandle.trim().replace(/^@/, "").toLowerCase();
+    if (!handle || !isValidHandle(handle)) {
+        return null;
+    }
+    return handle;
+}
+
+function isHandleResolutionError(error: unknown): boolean {
+    return (
+        errorMessage(error).startsWith("Failed to resolve identity:") ||
+        errorCauseHasCode(error, "did-unknown-error")
+    );
+}
+
+function errorCauseHasCode(error: unknown, code: string): boolean {
+    let current = error;
+    while (current && typeof current === "object") {
+        if ("code" in current && current.code === code) {
+            return true;
+        }
+        current = "cause" in current ? current.cause : undefined;
+    }
+    return false;
+}

--- a/worker/src/routes/sky-feeder/+page.server.ts
+++ b/worker/src/routes/sky-feeder/+page.server.ts
@@ -10,9 +10,12 @@ import {fail} from "@sveltejs/kit";
 const SUPPORTED_TIME_ZONES = new Set(Intl.supportedValuesOf("timeZone"));
 
 export async function load(event) {
+    const authError = authErrorMessage(
+        event.url.searchParams.get("auth_error")
+    );
     const {session} = await event.parent();
     if (!session) {
-        return;
+        return authError ? {authError} : undefined;
     }
 
     const controller = new SkyFeederController(event);
@@ -33,6 +36,7 @@ export async function load(event) {
     const prefs = resolvePrefs(session.prefs);
 
     return {
+        authError,
         profile,
         prefs,
         timelineFeedUrl: controller.timelineFeedUrl(session),
@@ -80,7 +84,8 @@ export const actions = {
     },
     "update-prefs": async event => {
         const formData = await event.request.formData();
-        const timeZone = formData.get("time_zone") as string | null;
+        const rawTimeZone = formData.get("time_zone");
+        const timeZone = typeof rawTimeZone === "string" ? rawTimeZone : null;
         if (!timeZone) {
             return fail(400, {
                 timezone: timeZone,
@@ -126,4 +131,11 @@ function errorCauseHasCode(error: unknown, code: string): boolean {
         current = "cause" in current ? current.cause : undefined;
     }
     return false;
+}
+
+function authErrorMessage(code: string | null): string | undefined {
+    if (code === "sign_in_failed") {
+        return "Bluesky sign-in was not completed. Try signing in again.";
+    }
+    return undefined;
 }

--- a/worker/src/routes/sky-feeder/+page.svelte
+++ b/worker/src/routes/sky-feeder/+page.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+    import {resolve} from "$app/paths";
+    import {APP_NAME} from "$lib/constants";
+    import FeedLink from "$lib/components/FeedLink.svelte";
+    import Layout from "$lib/components/Layout.svelte";
+
+    let {data, form} = $props();
+</script>
+
+<Layout title="Sky Feeder">
+    {#snippet intro()}
+        <p>
+            This <a href={resolve("/")}>{APP_NAME}</a> tool lets you subscribe to
+            your Bluesky timeline in a feed reader such as
+            <a href="https://netnewswire.com/">NetNewsWire</a>,
+            <a href="https://newsblur.com/">NewsBlur</a>,
+            <a href="https://reederapp.com/">Reeder</a> or
+            <a href="https://feedly.com/">Feedly</a>.
+        </p>
+
+        <p>
+            By signing in with your Bluesky account, you enable Sky Feeder to
+            generate feeds under "secret" URLs that contain posts from accounts
+            you follow.
+        </p>
+    {/snippet}
+
+    {#if data.session && data.profile}
+        You're signed in as <a
+            href={`https://bsky.app/profile/${data.profile.handle}`}
+            rel="external">@{data.profile.handle}</a>
+        (
+        <form action="?/sign-out" method="POST" class="inline-form">
+            <button>sign out</button>
+        </form>
+        )
+
+        <p>
+            Your <FeedLink href={data.timelineFeedUrl}
+                ><b>@{data.profile.handle} Bluesky timeline feed</b></FeedLink>
+            is ready (also available as <FeedLink
+                href={data.timelineJsonFeedUrl}
+                feedType="json">a JSON Feed</FeedLink
+            >). You can subscribe to the URL in your preferred feed reader.
+        </p>
+
+        {#if form?.error}
+            <p class="error">{form.error}</p>
+        {/if}
+
+        <form action="?/update-prefs" method="POST" class="prefs">
+            <fieldset>
+                <legend>Preferences</legend>
+                <label>
+                    Timezone:
+                    <select name="time_zone">
+                        {#each Intl.supportedValuesOf("timeZone") as timezone (timezone)}
+                            <option
+                                value={timezone}
+                                selected={timezone === data.prefs.timeZone}>
+                                {timezone}
+                            </option>
+                        {/each}
+                    </select>
+                    <div class="description">
+                        The timezone to use when formatting dates in the feed.
+                    </div>
+                </label>
+                <div class="buttons">
+                    <input type="submit" value="Update" />
+                </div>
+            </fieldset>
+        </form>
+    {:else}
+        <div class="sign-in">
+            <p>
+                To get started, sign in with Bluesky to allow Sky Feeder access
+                to your timeline.
+            </p>
+
+            {#if data.authError}
+                <p class="error">{data.authError}</p>
+            {/if}
+
+            {#if form?.error}
+                <p class="error">{form.error}</p>
+            {/if}
+
+            <form action="?/sign-in" method="POST" class="sign-in">
+                <input
+                    type="text"
+                    name="handle"
+                    value={form?.handle ?? ""}
+                    placeholder="your-handle.bsky.social"
+                    required
+                    size="30" />
+                <input type="submit" value="Sign In" />
+            </form>
+        </div>
+    {/if}
+
+    {#snippet footer()}
+        Feeds are exported under randomly-generated URLs. Though they should not
+        be guessable, they may end up "leaking" if accidentally sent to someone.
+
+        {#if data.session}
+            If that happens, you may wish to <form
+                action="?/reset-feed-id"
+                method="POST"
+                class="inline-form">
+                <button>reset</button>
+            </form>
+            your feed URLs.
+        {/if}
+    {/snippet}
+</Layout>
+
+<style>
+    .sign-in {
+        margin: 0 2em;
+    }
+
+    .sign-in form {
+        display: flex;
+        justify-content: center;
+    }
+
+    .sign-in form input[type="submit"] {
+        margin-left: 0.5em;
+    }
+
+    .inline-form {
+        display: inline;
+    }
+
+    .inline-form button {
+        -webkit-appearance: none;
+        appearance: none;
+        border: none;
+        background: none;
+        padding: 0;
+        color: #2db300;
+        text-decoration: underline;
+    }
+
+    .error {
+        background: #fdd;
+        padding: 0.5em;
+    }
+
+    .prefs {
+        margin: 1em 0;
+    }
+
+    .prefs fieldset {
+        border: solid 1px #00000066;
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+    }
+
+    .prefs .description {
+        color: #666;
+    }
+
+    .prefs .buttons {
+        display: flex;
+        justify-content: flex-end;
+    }
+</style>

--- a/worker/src/routes/sky-feeder/feed/[feedId]/timeline/+server.ts
+++ b/worker/src/routes/sky-feeder/feed/[feedId]/timeline/+server.ts
@@ -1,13 +1,14 @@
-import {MastoFeederController} from "$lib/masto-feeder/controller";
 import {parseFeedOptions} from "$lib/feeder/feed-options";
+import {SkyFeederController} from "$lib/sky-feeder/controller";
 import {error, type RequestHandler} from "@sveltejs/kit";
 
 export const GET: RequestHandler = async event => {
-    const controller = new MastoFeederController(event);
     const {feedId} = event.params;
     if (!feedId) {
         return error(400, "Invalid feed ID");
     }
+
+    const controller = new SkyFeederController(event);
     return controller.handleTimelineFeed(
         feedId,
         parseFeedOptions(event.url.searchParams)

--- a/worker/src/routes/sky-feeder/jwks.json/+server.ts
+++ b/worker/src/routes/sky-feeder/jwks.json/+server.ts
@@ -1,0 +1,7 @@
+import {SkyFeederController} from "$lib/sky-feeder/controller";
+import {type RequestHandler} from "@sveltejs/kit";
+
+export const GET: RequestHandler = async event => {
+    const controller = new SkyFeederController(event);
+    return controller.handleJwks();
+};

--- a/worker/src/routes/sky-feeder/oauth-client-metadata.json/+server.ts
+++ b/worker/src/routes/sky-feeder/oauth-client-metadata.json/+server.ts
@@ -1,0 +1,7 @@
+import {SkyFeederController} from "$lib/sky-feeder/controller";
+import {type RequestHandler} from "@sveltejs/kit";
+
+export const GET: RequestHandler = async event => {
+    const controller = new SkyFeederController(event);
+    return controller.handleOAuthClientMetadata();
+};

--- a/worker/src/routes/sky-feeder/sign-in-callback/+server.ts
+++ b/worker/src/routes/sky-feeder/sign-in-callback/+server.ts
@@ -1,0 +1,7 @@
+import {SkyFeederController} from "$lib/sky-feeder/controller";
+import {type RequestHandler} from "@sveltejs/kit";
+
+export const GET: RequestHandler = async event => {
+    const controller = new SkyFeederController(event);
+    return controller.handleSignInCallback(event.url.searchParams);
+};

--- a/worker/src/routes/tweeter-feeder/feed/+server.ts
+++ b/worker/src/routes/tweeter-feeder/feed/+server.ts
@@ -22,7 +22,7 @@ export const GET: RequestHandler = async event => {
             return error(e.status, message);
         }
         const message = errorToMessage(e);
-        console.error("Tweeter Feeder request failed", {message, error: e});
+        console.error("Tweeter Feeder request failed", {message});
         return error(500, message);
     }
 };

--- a/worker/src/routes/tweeter-feeder/statusz/+server.ts
+++ b/worker/src/routes/tweeter-feeder/statusz/+server.ts
@@ -1,3 +1,4 @@
+import {jsonResponse} from "$lib/feeder/response";
 import {WorkerKV} from "$lib/kv";
 import {errorToMessage, TwitterFetcher} from "$lib/tweeter-feeder/fetcher";
 import {TweeterFeederKV} from "$lib/tweeter-feeder/kv";
@@ -10,12 +11,12 @@ export const GET: RequestHandler = async event => {
     try {
         sessions = await tweeterKV.getSessions();
     } catch (e) {
-        return json(
+        return jsonResponse(
             {
                 ok: false,
                 error: errorToMessage(e),
             },
-            500
+            {status: 500}
         );
     }
 
@@ -25,14 +26,14 @@ export const GET: RequestHandler = async event => {
         checks.push(await checkSession(fetcher, sessions[i], i + 1));
     }
     const ok = checks.length > 0 && checks.every(check => check.ok);
-    return json(
+    return jsonResponse(
         {
             ok,
             checkedAtIso: new Date().toISOString(),
             sessionCount: sessions.length,
             checks,
         },
-        ok ? 200 : 500
+        {status: ok ? 200 : 500}
     );
 };
 
@@ -92,12 +93,3 @@ type SessionCheck = {
     profileUrl?: string;
     error?: string;
 };
-
-function json(value: unknown, status: number): Response {
-    return new Response(`${JSON.stringify(value, null, 2)}\n`, {
-        status,
-        headers: {
-            "Content-Type": "application/json; charset=utf-8",
-        },
-    });
-}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,8 +2,8 @@
 name = "streamspigot"
 account_id = "2ccb840de076261467812cbc32f8aa47"
 workers_dev = true
-compatibility_date = "2024-04-13"
-compatibility_flags = ["nodejs_als"]
+compatibility_date = "2026-05-14"
+compatibility_flags = ["nodejs_als", "nodejs_compat"]
 
 main = ".svelte-kit/cloudflare/_worker.js"
 

--- a/worker/wrangler.types.toml
+++ b/worker/wrangler.types.toml
@@ -6,8 +6,8 @@
 name = "streamspigot"
 account_id = "2ccb840de076261467812cbc32f8aa47"
 workers_dev = true
-compatibility_date = "2024-04-13"
-compatibility_flags = ["nodejs_als"]
+compatibility_date = "2026-05-14"
+compatibility_flags = ["nodejs_als", "nodejs_compat"]
 
 [assets]
 binding = "ASSETS"


### PR DESCRIPTION
## Summary

Adds Sky Feeder as a separate Stream Spigot tool for reading a signed-in Bluesky timeline through feed readers. It uses atproto OAuth sign-in, stores the resulting user/session state in KV, and publishes randomly generated Atom and JSON Feed timeline URLs.

## Architecture

Sky Feeder shares the provider-neutral pieces that already apply to Masto Feeder:

- common feed option parsing and feed-output response helpers under `worker/src/lib/feeder`
- shared preference defaults for things like feed timezone handling
- the existing normalized `Status` model and feed rendering pipeline
- the same random feed URL/session-management shape used by Masto Feeder

Provider-specific behavior stays separate under `worker/src/lib/sky-feeder` and `worker/src/routes/sky-feeder`:

- atproto OAuth client metadata and JWKS endpoints
- KV-backed OAuth state/session stores
- Bluesky timeline fetching
- Bluesky post/embed/repost/reply adaptation into the shared `Status` shape
- the Sky Feeder UI and feed endpoint routes

Masto Feeder is only touched where logic was extracted into shared helpers, so its Mastodon OAuth/app-registration behavior remains provider-specific.

## Bluesky / atproto notes

- Uses the current atproto TypeScript packages: `@atproto/api`, `@atproto/oauth-client-node`, `@atproto/did`, and the handle/DID resolver packages.
- Enables Worker `nodejs_compat` because DNS handle resolution needs Node-compatible APIs.
- Keeps custom Worker-safe OAuth fetch/DID resolution handling for Cloudflare runtime quirks.
- Requests read-scoped appview permissions for profile and timeline access rather than broad generic repository permissions.
- Handles Bluesky-specific feed details including quotes, reposts, images, video embeds, external cards, and parent reply links.
- Filters timeline replies so replies to people the viewer does not follow are hidden, while self-replies/threads and replies to followed accounts remain.
- Adds a narrow `GET /sky-feeder` redirect from `www.streamspigot.com` to `streamspigot.com`; broader canonical host handling is tracked separately in #9.